### PR TITLE
Fix storage errors

### DIFF
--- a/analytics-kotlin/src/main/java/com/segment/analytics/SegmentDestination.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/SegmentDestination.kt
@@ -85,7 +85,8 @@ class SegmentDestination(
             var initialDelay = flushIntervalInMillis
 
             // If we have events in queue flush them
-            val eventFilePaths = parseFilePaths(storage.read(Storage.Constants.Events)) // should we switch to extension function?
+            val eventFilePaths =
+                parseFilePaths(storage.read(Storage.Constants.Events)) // should we switch to extension function?
             if (eventFilePaths.isNotEmpty()) {
                 initialDelay = 0
             }
@@ -128,7 +129,8 @@ class SegmentDestination(
             try {
                 val connection = httpClient.upload(apiHost, apiKey)
                 val file = File(fileUrl)
-                if (!file.exists()) { // may have been deleted by scheduled flush
+                // flush is executed in a thread pool and file could have been deleted by another thread
+                if (!file.exists()) {
                     continue
                 }
                 connection.outputStream?.let {
@@ -158,11 +160,13 @@ class SegmentDestination(
                     )
                 }
             } catch (e: Exception) {
-                analytics.log("""
+                analytics.log(
+                    """
                     | Error uploading events from batch file
                     | fileUrl="$fileUrl"
                     | msg=${e.message}
-                """.trimMargin(), type = LogType.ERROR)
+                """.trimMargin(), type = LogType.ERROR
+                )
                 e.printStackTrace()
             }
         }

--- a/analytics-kotlin/src/main/java/com/segment/analytics/Storage.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/Storage.kt
@@ -2,6 +2,7 @@ package com.segment.analytics
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import com.segment.analytics.Storage.Companion.MAX_PAYLOAD_SIZE
 import com.segment.analytics.utilities.EventsFileManager
 import kotlinx.coroutines.CoroutineDispatcher
@@ -64,7 +65,7 @@ fun parseFilePaths(filePathStr: String?): List<String> {
     return if (filePathStr.isNullOrEmpty()) {
         emptyList()
     } else {
-        filePathStr.split(",")
+        filePathStr.split(",").map { it.trim() }
     }
 }
 
@@ -122,7 +123,7 @@ class AndroidStorage(
     override fun read(key: Storage.Constants): String? {
         return when (key) {
             Storage.Constants.Events -> {
-                eventsFile.read().joinToString()
+                eventsFile.read().also { Log.d("PRAY","Reading $it") }.joinToString()
             }
             else -> {
                 sharedPreferences.getString(key.rawVal, null)
@@ -143,6 +144,7 @@ class AndroidStorage(
     }
 
     override fun removeFile(filePath: String): Boolean {
+        Log.d("PRAY","Deleting: $filePath")
         return eventsFile.remove(filePath)
     }
 }

--- a/analytics-kotlin/src/main/java/com/segment/analytics/Storage.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/Storage.kt
@@ -2,7 +2,6 @@ package com.segment.analytics
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import com.segment.analytics.Storage.Companion.MAX_PAYLOAD_SIZE
 import com.segment.analytics.utilities.EventsFileManager
 import kotlinx.coroutines.CoroutineDispatcher
@@ -123,7 +122,7 @@ class AndroidStorage(
     override fun read(key: Storage.Constants): String? {
         return when (key) {
             Storage.Constants.Events -> {
-                eventsFile.read().also { Log.d("PRAY","Reading $it") }.joinToString()
+                eventsFile.read().joinToString()
             }
             else -> {
                 sharedPreferences.getString(key.rawVal, null)
@@ -144,7 +143,6 @@ class AndroidStorage(
     }
 
     override fun removeFile(filePath: String): Boolean {
-        Log.d("PRAY","Deleting: $filePath")
         return eventsFile.remove(filePath)
     }
 }

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
@@ -54,16 +54,5 @@ class MainApplication : Application() {
         analytics.add(WebhookPlugin("https://webhook.site/387c1740-f919-4446-a26e-a9a01ed28c8a", Executors.newSingleThreadExecutor()))
 
         analytics.add(AndroidAdvertisingIdPlugin(this))
-
-        analytics.add(object: Logger("CustomLogger") {
-            override fun log(type: LogType, message: String, event: BaseEvent?) {
-                if (message.contains("Error uploading events from batch file")) {
-                    val dir = applicationContext.getDir("segment-disk-queue", Context.MODE_PRIVATE)
-                    val files = dir.listFiles().map{ it.absolutePath}
-                    Log.d(name, files.toString())
-                    Log.d(name, message)
-                }
-            }
-        })
     }
 }

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
@@ -1,11 +1,15 @@
 package com.segment.analytics.next
 
 import android.app.Application
+import android.content.Context
+import android.util.Log
 import com.segment.analytics.*
 import com.segment.analytics.next.plugins.AndroidAdvertisingIdPlugin
 import com.segment.analytics.next.plugins.AndroidRecordScreenPlugin
 import com.segment.analytics.next.plugins.WebhookPlugin
 import com.segment.analytics.platform.Plugin
+import com.segment.analytics.platform.plugins.LogType
+import com.segment.analytics.platform.plugins.Logger
 import com.segment.analytics.utilities.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -50,5 +54,16 @@ class MainApplication : Application() {
         analytics.add(WebhookPlugin("https://webhook.site/387c1740-f919-4446-a26e-a9a01ed28c8a", Executors.newSingleThreadExecutor()))
 
         analytics.add(AndroidAdvertisingIdPlugin(this))
+
+        analytics.add(object: Logger("CustomLogger") {
+            override fun log(type: LogType, message: String, event: BaseEvent?) {
+                if (message.contains("Error uploading events from batch file")) {
+                    val dir = applicationContext.getDir("segment-disk-queue", Context.MODE_PRIVATE)
+                    val files = dir.listFiles().map{ it.absolutePath}
+                    Log.d(name, files.toString())
+                    Log.d(name, message)
+                }
+            }
+        })
     }
 }

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
@@ -1,15 +1,11 @@
 package com.segment.analytics.next
 
 import android.app.Application
-import android.content.Context
-import android.util.Log
 import com.segment.analytics.*
 import com.segment.analytics.next.plugins.AndroidAdvertisingIdPlugin
 import com.segment.analytics.next.plugins.AndroidRecordScreenPlugin
 import com.segment.analytics.next.plugins.WebhookPlugin
 import com.segment.analytics.platform.Plugin
-import com.segment.analytics.platform.plugins.LogType
-import com.segment.analytics.platform.plugins.Logger
 import com.segment.analytics.utilities.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers


### PR DESCRIPTION
Storage was logging errors due to missing files. This was stemming from a thread pool working on the files and deleting them.  The following changes will make sure files exist before we try to process them