### PR TITLE
Add push notification tracking example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,12 @@ buildscript {
         classpath "com.android.tools.build:gradle:4.1.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-        classpath("de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1") // needed for android unit tests
+
+        // needed for android unit tests
+        classpath("de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+        classpath 'com.google.gms:google-services:4.3.5'
     }
 }
 

--- a/samples/kotlin-android-app/.gitignore
+++ b/samples/kotlin-android-app/.gitignore
@@ -1,1 +1,2 @@
 /build
+google-services.json

--- a/samples/kotlin-android-app/.gitignore
+++ b/samples/kotlin-android-app/.gitignore
@@ -1,2 +1,1 @@
 /build
-google-services.json

--- a/samples/kotlin-android-app/README.md
+++ b/samples/kotlin-android-app/README.md
@@ -25,7 +25,8 @@ adb shell am start -W -a android.intent.action.VIEW -d "https://segment-sample.c
 
 ## FCM
 This project is setup to track push notification received and opened events. This code is strictly optional and must be customized as per your needs. The code here is only for demonstration purposes
-- Add your project's google-services.json to this folder
+### Setup
+- Add your FCM project's `google-services.json` to this folder
 - Modify `MyFirebaseService.kt` to customize the notification displayed to the user.
 - Here is how to send a push notification using cURL [this uses the legacy api](https://firebase.google.com/docs/cloud-messaging/send-message#send-messages-using-the-legacy-app-server-protocols)
 ```bash
@@ -42,7 +43,9 @@ curl --request POST \
 }'
 ```
 
-How it works
+### How it works
 - We have 2 core changes
   - MyFirebaseService.kt
+  The core component to handle FCM push messages. This is responsible for handling the incoming message and assigning the intents for the notification. It is also responsible for firing the `Push Notification Received` event.
   - PushNotificationTracking.kt
+  The analytics plugin responsible for firing the "Push Notification Tapped" event. This is a lifecycle plugin that will be invoked for any Activity onCreate.

--- a/samples/kotlin-android-app/README.md
+++ b/samples/kotlin-android-app/README.md
@@ -22,3 +22,27 @@ Here is how you can do it via adb
 ```bash
 adb shell am start -W -a android.intent.action.VIEW -d "https://segment-sample.com?utm_source=cli\&utm_click=2" com.segment.analytics.next
 ```
+
+## FCM
+This project is setup to track push notification received and opened events. This code is strictly optional and must be customized as per your needs. The code here is only for demonstration purposes
+- Add your project's google-services.json to this folder
+- Modify `MyFirebaseService.kt` to customize the notification displayed to the user.
+- Here is how to send a push notification using cURL [this uses the legacy api](https://firebase.google.com/docs/cloud-messaging/send-message#send-messages-using-the-legacy-app-server-protocols)
+```bash
+curl --request POST \
+  --url https://fcm.googleapis.com/fcm/send \
+  --header 'Authorization: key=<SERVER_KEY>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"data": {
+		"title": "Hello World"
+		"content": "You have mail",
+	},
+	"to": "<FCM_TOKEN_FOR_DEVICE>"
+}'
+```
+
+How it works
+- We have 2 core changes
+  - MyFirebaseService.kt
+  - PushNotificationTracking.kt

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'org.jetbrains.kotlin.plugin.serialization'
+    id 'com.google.gms.google-services'
 }
 
 android {
@@ -54,6 +55,10 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.3.1'
 
     implementation 'com.google.android.gms:play-services-ads:20.0.0'
+
+    implementation platform('com.google.firebase:firebase-bom:27.1.0')
+    implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation 'com.google.firebase:firebase-messaging:19.0.0'
 
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/samples/kotlin-android-app/google-services.json
+++ b/samples/kotlin-android-app/google-services.json
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "563414602026",
+    "project_id": "segment-sample-6f133",
+    "storage_bucket": "segment-sample-6f133.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:563414602026:android:c7050fbaa3bcd8e6dd0e53",
+        "android_client_info": {
+          "package_name": "com.segment.analytics.next"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "563414602026-9ao5va0s6mjhcpa1d6im903jlv1l20ue.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCnJY7sJnjjUi89bH6K7TE8W9MCozjkpo4"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "563414602026-9ao5va0s6mjhcpa1d6im903jlv1l20ue.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/samples/kotlin-android-app/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app/src/main/AndroidManifest.xml
@@ -42,6 +42,13 @@
                     android:scheme="https" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".MyFirebaseService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
@@ -68,7 +68,7 @@ class MainApplication : Application() {
 
         FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
             if (!task.isSuccessful) {
-                Log.w("PRAY", "Fetching FCM registration token failed", task.exception)
+                Log.w("SegmentSample", "Fetching FCM registration token failed", task.exception)
                 return@OnCompleteListener
             }
 
@@ -76,7 +76,7 @@ class MainApplication : Application() {
             val token = task.result
 
             // Log and toast
-            Log.d("PRAY", token)
+            Log.d("SegmentSample", token)
         })
     }
 }

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainApplication.kt
@@ -1,15 +1,24 @@
 package com.segment.analytics.next
 
+import android.app.Activity
 import android.app.Application
+import android.os.Bundle
+import android.util.Log
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
 import com.segment.analytics.*
 import com.segment.analytics.next.plugins.AndroidAdvertisingIdPlugin
 import com.segment.analytics.next.plugins.AndroidRecordScreenPlugin
+import com.segment.analytics.next.plugins.PushNotificationTracking
 import com.segment.analytics.next.plugins.WebhookPlugin
 import com.segment.analytics.platform.Plugin
+import com.segment.analytics.platform.plugins.android.AndroidLifecycle
 import com.segment.analytics.utilities.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import java.util.concurrent.Executors
 
 class MainApplication : Application() {
@@ -46,9 +55,28 @@ class MainApplication : Application() {
             }
 
         })
+        analytics.add(PushNotificationTracking)
         // A random webhook url to view your events
-        analytics.add(WebhookPlugin("https://webhook.site/387c1740-f919-4446-a26e-a9a01ed28c8a", Executors.newSingleThreadExecutor()))
+        analytics.add(
+            WebhookPlugin(
+                "https://webhook.site/387c1740-f919-4446-a26e-a9a01ed28c8a",
+                Executors.newSingleThreadExecutor()
+            )
+        )
 
         analytics.add(AndroidAdvertisingIdPlugin(this))
+
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                Log.w("PRAY", "Fetching FCM registration token failed", task.exception)
+                return@OnCompleteListener
+            }
+
+            // Get new FCM registration token
+            val token = task.result
+
+            // Log and toast
+            Log.d("PRAY", token)
+        })
     }
 }

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MyFirebaseService.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MyFirebaseService.kt
@@ -35,7 +35,7 @@ class MyFirebaseService : FirebaseMessagingService() {
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
-        Log.d("PRAY", "push notification received")
+        Log.d("SegmentSample", "push notification received")
         super.onMessageReceived(remoteMessage)
         val data = remoteMessage.data
         val title = data["title"]

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MyFirebaseService.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MyFirebaseService.kt
@@ -1,0 +1,79 @@
+package com.segment.analytics.next
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.media.AudioAttributes
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.iid.FirebaseInstanceId
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class MyFirebaseService : FirebaseMessagingService() {
+
+    val TAG = "MyFirebaseService"
+
+    override fun onNewToken(s: String) {
+        Log.e(TAG, s)
+        FirebaseInstanceId.getInstance().instanceId
+            .addOnCompleteListener(OnCompleteListener { task ->
+                if (!task.isSuccessful) {
+                    Log.w(TAG, "getInstanceId failed", task.exception)
+                    return@OnCompleteListener
+                }
+
+                // Get new Instance ID token
+                val token = task.result.token
+                Log.e(TAG, token)
+            })
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        Log.d("PRAY", "push notification received")
+        super.onMessageReceived(remoteMessage)
+        val data = remoteMessage.data
+        val title = data["title"]
+        val body = data["content"]
+
+        MainApplication.analytics.track("Push Notification Received", buildJsonObject {
+            val campaign = buildJsonObject {
+                put("medium", "Push")
+                put("source", "FCM")
+                put("name", title)
+                put("content", body)
+            }
+            put("campaign", campaign)
+        })
+
+        val intent = Intent(applicationContext, MainActivity::class.java).apply {
+            putExtra("push_notification", true)
+        }
+        val pi = PendingIntent.getActivity(applicationContext, 101, intent, 0)
+        val nm = applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        var channel: NotificationChannel? = null
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val att = AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                .build()
+            channel = NotificationChannel("222", "my_channel", NotificationManager.IMPORTANCE_HIGH)
+            nm.createNotificationChannel(channel)
+        }
+        val builder = NotificationCompat.Builder(applicationContext, "222")
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(body)
+            .setAutoCancel(true)
+            .setContentText(title)
+            .setContentIntent(pi)
+            .setDeleteIntent(pi)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+
+        nm.notify(123456789, builder.build())
+    }
+}

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/plugins/PushNotificationTracking.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/plugins/PushNotificationTracking.kt
@@ -1,0 +1,46 @@
+package com.segment.analytics.next.plugins
+
+import android.app.Activity
+import android.os.Bundle
+import android.util.Log
+import com.segment.analytics.Analytics
+import com.segment.analytics.platform.Plugin
+import com.segment.analytics.platform.plugins.android.AndroidLifecycle
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+object PushNotificationTracking: Plugin, AndroidLifecycle {
+    override val type: Plugin.Type = Plugin.Type.Utility
+    override val name: String = "PushNotificationTracking"
+    override lateinit var analytics: Analytics
+
+    override fun onActivityCreated(activity: Activity?, savedInstanceState: Bundle?) {
+        val bundle = if (savedInstanceState == null) {
+            activity?.intent?.extras
+        } else {
+            Bundle().apply {
+                putAll(savedInstanceState)
+                putAll(activity?.intent?.extras)
+            }
+        }
+        checkPushNotification(bundle)
+    }
+
+    private fun checkPushNotification(bundle: Bundle?) {
+        if (bundle != null) {
+            if (bundle.containsKey("push_notification")) {
+                Log.d("PRAY-Plugin", "push notification = yes")
+                analytics.track("Push Notification Tapped", buildJsonObject {
+                    put("action", "Open")
+                    val campaign = buildJsonObject {
+                        put("medium", "Push")
+                        put("source", "FCM")
+                        put("name", bundle.getString("title"))
+                        put("content", bundle.getString("content"))
+                    }
+                    put("campaign", campaign)
+                })
+            }
+        }
+    }
+}

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/plugins/PushNotificationTracking.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/plugins/PushNotificationTracking.kt
@@ -29,7 +29,6 @@ object PushNotificationTracking: Plugin, AndroidLifecycle {
     private fun checkPushNotification(bundle: Bundle?) {
         if (bundle != null) {
             if (bundle.containsKey("push_notification")) {
-                Log.d("PRAY-Plugin", "push notification = yes")
                 analytics.track("Push Notification Tapped", buildJsonObject {
                     put("action", "Open")
                     val campaign = buildJsonObject {


### PR DESCRIPTION
Updated kotlin-sample-app to instrument push notification tracking. This is to serve as an example for users to implement in their own applications.

The logic utilises the android application lifecycle hooks and firebase messaging service to track the push notifications, following this [guide](https://medium.com/nybles/sending-push-notifications-by-using-firebase-cloud-messaging-249aa34f4f4c)