### PR TITLE
Startup Queue Logic

### DIFF
--- a/analytics-kotlin/src/main/java/com/segment/analytics/Analytics.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/Analytics.kt
@@ -71,6 +71,9 @@ class Analytics(internal val configuration: Configuration) : Subscriber {
             ) { state: System ->
                 state.settings?.let { settings ->
                     timeline.applyClosure { plugin -> plugin.update(settings) }
+
+                    // We received settings, mark system as started
+                    store.dispatch(System.SetStartedAction(true), System::class)
                 }
             }
         }
@@ -362,13 +365,29 @@ class Analytics(internal val configuration: Configuration) : Subscriber {
      * @param plugin [Plugin] to be added
      */
     fun add(plugin: Plugin): Analytics {
-        // could be done in background thread
+        // we need to know if the system is already started.
+        val wasStarted = store.currentState(System::class)?.started ?: false
+        if (wasStarted) {
+            // if it was started, we need to stop it temporarily.
+            store.dispatch(System.SetStartedAction(false), System::class)
+            // adding the plugin to the timeline below will eventually call
+            // update(settings:) at which point, we can start it up again.
+        }
+
         this.timeline.add(plugin)
         if (plugin is DestinationPlugin && plugin.name != "Segment.io") {
             analyticsScope.launch(ioDispatcher) {
                 store.dispatch(System.AddIntegrationAction(plugin.name), System::class)
             }
         }
+
+        // if the timeline had started before, set it back to started since
+        // update(settings:) will have been called by now.
+        if (wasStarted) {
+            // fixme why do we need to do this manually since `update` should do it
+            store.dispatch(System.SetStartedAction(true), System::class)
+        }
+
         return this
     }
 

--- a/analytics-kotlin/src/main/java/com/segment/analytics/Analytics.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/Analytics.kt
@@ -3,6 +3,7 @@ package com.segment.analytics
 import com.segment.analytics.platform.DestinationPlugin
 import com.segment.analytics.platform.Plugin
 import com.segment.analytics.platform.Timeline
+import com.segment.analytics.platform.plugins.StartupQueue
 import com.segment.analytics.platform.plugins.log
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -79,6 +80,7 @@ class Analytics(internal val configuration: Configuration) : Subscriber {
         }
 
         checkSettings()
+        add(StartupQueue())
         if (configuration.autoAddSegmentDestination) {
             add(
                 SegmentDestination(

--- a/analytics-kotlin/src/main/java/com/segment/analytics/Settings.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/Settings.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import java.io.BufferedReader
-import java.util.zip.GZIPInputStream
 
 @Serializable
 data class Settings(
@@ -17,15 +16,26 @@ data class Settings(
     var edgeFunction: JsonObject = emptyJsonObject,
 )
 
+internal fun Analytics.update(settings: Settings) {
+    timeline.applyClosure { plugin ->
+        // tell all top level plugins to update.
+        // For destination plugins they auto-handle propagation to sub-plugins
+        plugin.update(settings)
+    }
+}
+
 /**
  * Make analytics client call into Segment's settings API, to refresh certain configurations.
  */
 fun Analytics.checkSettings() {
     val writeKey = configuration.writeKey
-    val defaultSettings = configuration.defaultSettings
+
+    // stop things; queue in case our settings have changed.
+    store.dispatch(System.ToggleRunningAction(running = false), System::class)
+
     analyticsScope.launch(ioDispatcher) {
         log("Fetching settings on ${Thread.currentThread().name}")
-        val settingsObj: Settings = try {
+        val settingsObj: Settings? = try {
             val connection = HTTPClient().settings(writeKey)
             val settingsString =
                 connection.inputStream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
@@ -33,9 +43,15 @@ fun Analytics.checkSettings() {
             Json { ignoreUnknownKeys = true }.decodeFromString(settingsString)
         } catch (ex: Exception) {
             log(message = "${ex.message}: failed to fetch settings", type = LogType.ERROR)
-            defaultSettings
+            null
         }
-        log("Dispatching update settings on ${Thread.currentThread().name}")
-        store.dispatch(System.UpdateSettingsAction(settingsObj), System::class)
+        settingsObj?.let {
+            log("Dispatching update settings on ${Thread.currentThread().name}")
+            store.dispatch(System.UpdateSettingsAction(settingsObj), System::class)
+            update(settingsObj)
+        }
+
+        // we're good to go back to a running state.
+        store.dispatch(System.ToggleRunningAction(running = true), System::class)
     }
 }

--- a/analytics-kotlin/src/main/java/com/segment/analytics/State.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/State.kt
@@ -16,7 +16,7 @@ data class System(
     var configuration: Configuration = Configuration(""),
     var integrations: Integrations?,
     var settings: Settings?,
-    var started: Boolean
+    var running: Boolean
 ) : State {
 
     companion object {
@@ -33,7 +33,7 @@ data class System(
                 configuration = configuration,
                 integrations = emptyJsonObject,
                 settings = settings,
-                started = false
+                running = false
             )
         }
     }
@@ -44,7 +44,7 @@ data class System(
                 state.configuration,
                 state.integrations,
                 settings,
-                state.started
+                state.running
             )
         }
     }
@@ -62,7 +62,7 @@ data class System(
                     state.configuration,
                     JsonObject(newIntegrations),
                     state.settings,
-                    state.started
+                    state.running
                 )
             }
             return state
@@ -78,20 +78,20 @@ data class System(
                     state.configuration,
                     JsonObject(newIntegrations),
                     state.settings,
-                    state.started
+                    state.running
                 )
             }
             return state
         }
     }
 
-    class SetStartedAction(var started: Boolean): Action<System> {
+    class ToggleRunningAction(var running: Boolean): Action<System> {
         override fun reduce(state: System): System {
             return System(
                 state.configuration,
                 state.integrations,
                 state.settings,
-                started
+                running
             )
         }
     }

--- a/analytics-kotlin/src/main/java/com/segment/analytics/State.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/State.kt
@@ -15,7 +15,8 @@ import kotlin.collections.set
 data class System(
     var configuration: Configuration = Configuration(""),
     var integrations: Integrations?,
-    var settings: Settings?
+    var settings: Settings?,
+    var started: Boolean
 ) : State {
 
     companion object {
@@ -32,6 +33,7 @@ data class System(
                 configuration = configuration,
                 integrations = emptyJsonObject,
                 settings = settings,
+                started = false
             )
         }
     }
@@ -41,7 +43,8 @@ data class System(
             return System(
                 state.configuration,
                 state.integrations,
-                settings
+                settings,
+                state.started
             )
         }
     }
@@ -58,7 +61,8 @@ data class System(
                 return System(
                     state.configuration,
                     JsonObject(newIntegrations),
-                    state.settings
+                    state.settings,
+                    state.started
                 )
             }
             return state
@@ -73,10 +77,22 @@ data class System(
                 return System(
                     state.configuration,
                     JsonObject(newIntegrations),
-                    state.settings
+                    state.settings,
+                    state.started
                 )
             }
             return state
+        }
+    }
+
+    class SetStartedAction(var started: Boolean): Action<System> {
+        override fun reduce(state: System): System {
+            return System(
+                state.configuration,
+                state.integrations,
+                state.settings,
+                started
+            )
         }
     }
 }

--- a/analytics-kotlin/src/main/java/com/segment/analytics/platform/plugins/StartupQueue.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/platform/plugins/StartupQueue.kt
@@ -30,7 +30,7 @@ class StartupQueue(): Plugin, Subscriber {
 
     override fun execute(event: BaseEvent): BaseEvent? {
         if (!started.get()) {
-            analytics.log("PRAY-message-queuing")
+            analytics.log("$name queueing event", event = event)
             // timeline hasn't started, so queue it up.
             if (queuedEvents.size >= maxSize) {
                 // if we've exceeded the max queue size start dropping events
@@ -39,7 +39,6 @@ class StartupQueue(): Plugin, Subscriber {
             queuedEvents.offer(event)
             return null
         }
-        analytics.log("PRAY-message-not-queuing")
         // the timeline has started, so let the event pass.
         return event
     }

--- a/analytics-kotlin/src/main/java/com/segment/analytics/platform/plugins/StartupQueue.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/platform/plugins/StartupQueue.kt
@@ -44,6 +44,7 @@ class StartupQueue(): Plugin, Subscriber {
 
     // Handler to manage system update
     private fun systemUpdate(state: System) {
+        analytics.log("Analytics starting = ${state.started}")
         started.set(state.started)
         if (started.get()) {
             replayEvents()

--- a/analytics-kotlin/src/main/java/com/segment/analytics/platform/plugins/StartupQueue.kt
+++ b/analytics-kotlin/src/main/java/com/segment/analytics/platform/plugins/StartupQueue.kt
@@ -1,0 +1,60 @@
+package com.segment.analytics.platform.plugins
+
+import com.segment.analytics.Analytics
+import com.segment.analytics.BaseEvent
+import com.segment.analytics.platform.Plugin
+import com.segment.analytics.System
+import sovran.kotlin.Subscriber
+import java.util.Queue
+import java.util.LinkedList
+import java.util.concurrent.atomic.AtomicBoolean
+
+class StartupQueue(): Plugin, Subscriber {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override val name: String = "Segment_StartupQueue"
+    override lateinit var analytics: Analytics
+
+    private val maxSize = 1000
+    private val started: AtomicBoolean = AtomicBoolean(false)
+    private val queuedEvents: Queue<BaseEvent> = LinkedList()
+
+    override fun setup(analytics: Analytics) {
+        super.setup(analytics)
+        analytics.store.subscribe(
+            subscriber = this,
+            stateClazz = System::class,
+            initialState = true,
+            handler = this::systemUpdate
+        )
+    }
+
+    override fun execute(event: BaseEvent): BaseEvent? {
+        if (!started.get()) {
+            // timeline hasn't started, so queue it up.
+            if (queuedEvents.size >= maxSize) {
+                // if we've exceeded the max queue size start dropping events
+                queuedEvents.remove()
+            }
+            queuedEvents.offer(event)
+            return null
+        }
+        // the timeline has started, so let the event pass.
+        return event
+    }
+
+    // Handler to manage system update
+    private fun systemUpdate(state: System) {
+        started.set(state.started)
+        if (started.get()) {
+            replayEvents()
+        }
+    }
+
+    private fun replayEvents() {
+        // replay the queued events to the instance of Analytics we're working with.
+        for (event in queuedEvents) {
+            analytics.process(event)
+        }
+        queuedEvents.clear()
+    }
+}

--- a/analytics-kotlin/src/test/java/com/segment/analytics/main/StorageTests.kt
+++ b/analytics-kotlin/src/test/java/com/segment/analytics/main/StorageTests.kt
@@ -3,6 +3,7 @@ package com.segment.analytics.main
 import android.content.Context
 import android.content.SharedPreferences
 import com.segment.analytics.*
+import com.segment.analytics.System
 import com.segment.analytics.main.utils.MemorySharedPreferences
 import com.segment.analytics.main.utils.mockAnalytics
 import com.segment.analytics.main.utils.mockContext
@@ -20,7 +21,6 @@ import java.util.*
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 import org.junit.jupiter.api.Assertions.*
-import java.io.IOException
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class StorageTests {
@@ -47,7 +47,8 @@ class StorageTests {
                 System(
                     configuration = Configuration("123"),
                     integrations = emptyJsonObject,
-                    settings = Settings()
+                    settings = Settings(),
+                    false
                 )
             )
 
@@ -103,7 +104,8 @@ class StorageTests {
                             },
                             plan = emptyJsonObject,
                             edgeFunction = emptyJsonObject
-                        )
+                        ),
+                        false
                     )
                 }
             }


### PR DESCRIPTION
## Purpose
If the analytics instance has not yet received a settings update, then most destinations arent ready for the incoming events. This change will allow us to pause the analytics instance and **queue up** any incoming events until the instance has received settings.

## Approach
We add a new plugin called `StartupQueue` which queues up events (in memory) until the analytics instance is `running`. The `running` state is managed via `sovran-kotlin` and is initialized as false when first started and only set to true when we have successfully fetched the settings. The running state is also set to false in between settings updates and then re-set to true once the update is finished