### PR TITLE
add new helpers for destinations work

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/JSON.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/JSON.kt
@@ -82,3 +82,13 @@ fun JsonObject.getMapSet(key: String): Set<Map<String, Any>>? {
     else
         null
 }
+
+// Utility function to transform keys in JsonObject. Only acts on root level keys
+fun JsonObject.transformKeys(transform: (String) -> String): JsonObject {
+    return JsonObject(this.mapKeys { transform(it.key) })
+}
+
+// Utility function to transform values in JsonObject. Only acts on root level values
+fun JsonObject.transformValues(transform: (JsonElement) -> JsonElement): JsonObject {
+    return JsonObject(this.mapValues { transform(it.value) })
+}

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/JSONTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/JSONTests.kt
@@ -6,7 +6,10 @@ import com.segment.analytics.kotlin.core.utilities.getInt
 import com.segment.analytics.kotlin.core.utilities.getMapSet
 import com.segment.analytics.kotlin.core.utilities.getString
 import com.segment.analytics.kotlin.core.utilities.getStringSet
+import com.segment.analytics.kotlin.core.utilities.transformKeys
+import com.segment.analytics.kotlin.core.utilities.transformValues
 import kotlinx.serialization.json.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.fail
@@ -193,7 +196,8 @@ class JSONTests {
 
     @Test
     fun `get normal string set`() {
-        val jsonObject = JsonObject(mapOf("keyed" to buildJsonArray { add("joker"); add("batman"); add("Mr. Freeze") }))
+        val jsonObject =
+            JsonObject(mapOf("keyed" to buildJsonArray { add("joker"); add("batman"); add("Mr. Freeze") }))
 
         val keyedValue = jsonObject.getStringSet("keyed")
 
@@ -204,7 +208,9 @@ class JSONTests {
 
     @Test
     fun `get normal string set with duplicate`() {
-        val jsonObject = JsonObject(mapOf("keyed" to buildJsonArray { add("joker"); add("batman"); add("Mr. Freeze"); add("batman") }))
+        val jsonObject = JsonObject(mapOf("keyed" to buildJsonArray {
+            add("joker"); add("batman"); add("Mr. Freeze"); add("batman")
+        }))
 
         val keyedValue = jsonObject.getStringSet("keyed")
 
@@ -214,7 +220,9 @@ class JSONTests {
 
     @Test
     fun `get normal string set with improper lookup`() {
-        val jsonObject = JsonObject(mapOf("keyed" to buildJsonArray { add("joker"); add("batman"); add("Mr. Freeze"); add("batman") }))
+        val jsonObject = JsonObject(mapOf("keyed" to buildJsonArray {
+            add("joker"); add("batman"); add("Mr. Freeze"); add("batman")
+        }))
 
         val keyedValue = jsonObject.getStringSet("keyed")
 
@@ -263,7 +271,8 @@ class JSONTests {
 
     @Test
     fun `get normal string set map with duplicate`() {
-        val batmanMap = mapOf("villains" to buildJsonArray { add("Joker"); add("Bain"); add("Mr. Freeze"); add("Bain") },
+        val batmanMap =
+            mapOf("villains" to buildJsonArray { add("Joker"); add("Bain"); add("Mr. Freeze"); add("Bain") },
                 "heroes" to buildJsonArray { add("Batman"); add("Robin"); add("James Gordon"); add("Catwoman") })
         val jsonObject = JsonObject(mapOf("batman" to JsonObject(batmanMap)))
 
@@ -287,5 +296,45 @@ class JSONTests {
 
         // Make sure there is still 4 and that it did not remove an additional Bain
         assertTrue(retrievedMap.intOrNull == 18)
+    }
+
+    @Test
+    fun `transformKeys transforms keys correctly`() {
+        val map = buildJsonObject {
+            put("Joker", true)
+            put("Catwoman", false)
+            put("Mr. Freeze", true)
+        }
+
+        val newMap = map.transformKeys { it.toUpperCase() }
+
+        with(newMap) {
+            assertTrue(containsKey("JOKER"))
+            assertTrue(containsKey("CATWOMAN"))
+            assertTrue(containsKey("MR. FREEZE"))
+        }
+    }
+
+    @Test
+    fun `transformValues transforms values correctly`() {
+        val map = buildJsonObject {
+            put("Joker", true)
+            put("Catwoman", false)
+            put("Mr. Freeze", true)
+        }
+
+        val newMap = map.transformValues {
+            if (it.jsonPrimitive.boolean) {
+                JsonPrimitive("M")
+            } else {
+                JsonPrimitive("F")
+            }
+        }
+
+        with(newMap) {
+            assertEquals("M", getString("Joker"))
+            assertEquals("F", getString("Catwoman"))
+            assertEquals("M", getString("Mr. Freeze"))
+        }
     }
 }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/SettingsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/SettingsTests.kt
@@ -5,9 +5,14 @@ import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
@@ -84,6 +89,65 @@ class SettingsTests {
                     edgeFunction = emptyJsonObject
                 )
             )
+        }
+    }
+
+    @Test
+    fun `isDestinationEnabled returns true when present`() {
+        val settings = Settings(
+            integrations = buildJsonObject {
+                put("Foo", buildJsonObject {
+                    put("configA", true)
+                })
+                put("Bar", buildJsonObject {
+                    put("configC", 10)
+                })
+            }
+        )
+
+        assertTrue(settings.isDestinationEnabled("Foo"))
+        assertTrue(settings.isDestinationEnabled("Bar"))
+    }
+
+    @Test
+    fun `isDestinationEnabled returns false when absent`() {
+        val settings = Settings(
+            integrations = buildJsonObject {
+                put("Foo", buildJsonObject {
+                    put("configA", true)
+                })
+            }
+        )
+
+        assertTrue(settings.isDestinationEnabled("Foo"))
+        assertFalse(settings.isDestinationEnabled("Bar"))
+    }
+
+    @Serializable
+    data class FooConfig(
+        var configA: Boolean,
+        var configB: Int,
+        var configC: String
+    )
+
+    @Test
+    fun `can fetch typed settings correctly`() {
+        val settings = Settings(
+            integrations = buildJsonObject {
+                put("Foo", buildJsonObject {
+                    put("configA", true)
+                    put("configB", 10)
+                    put("configC", "something")
+                })
+            }
+        )
+
+        val typedSettings = settings.destinationSettings<FooConfig>("Foo")
+        assertNotNull(typedSettings)
+        with(typedSettings!!) {
+            assertTrue(configA)
+            assertEquals(10, configB)
+            assertEquals("something", configC)
         }
     }
 }


### PR DESCRIPTION
I am adding a bunch of new functions/apis that will aid in building new destinations.

```
+ Settings.isDestinationEnabled(name: String)
+ Settings.destinationSettings(name: String) // Will produce a typed config

+ JsonObject.transformKeys(transform: (String) -> String)
+ JsonObject.transformValuestransform: (String) -> String)
```