### PR TITLE
add consumer proguard rules

### DIFF
--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,16 @@
+# kotlinx-serialization-json specific. Add this if you have java.lang.NoClassDefFoundError kotlinx.serialization.json.JsonObjectSerializer
+-keepclassmembers class kotlinx.serialization.json.** {
+    *** Companion;
+}
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# These rules will ensure that our generated serializers dont get obfuscated
+-keep,includedescriptorclasses class com.segment.analytics.kotlin.**$$serializer { *; }
+-keepclassmembers class com.segment.analytics.kotlin.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.segment.analytics.kotlin.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}


### PR DESCRIPTION
#20 raised an issue with proguard not being correctly configured during minification. Updating our consumer proguard rules to ensure that the compiler generated serializers do not throw exceptions when minified.