### PR TITLE
Add a base64 encoding implementation

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
@@ -1,5 +1,6 @@
 package com.segment.analytics.kotlin.core
 
+import com.segment.analytics.kotlin.core.utilities.encodeToBase64
 import java.io.BufferedReader
 import java.io.Closeable
 import java.io.IOException
@@ -34,7 +35,7 @@ class HTTPClient {
 
     private fun authorizationHeader(writeKey: String): String {
         val auth = "$writeKey:"
-        return "Basic " + Base64.getEncoder().encodeToString(auth.toByteArray())
+        return "Basic ${encodeToBase64(auth)}"
     }
 
     /**

--- a/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
@@ -9,7 +9,6 @@ import java.io.OutputStream
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
-import java.util.Base64
 import java.util.zip.GZIPOutputStream
 
 class HTTPClient {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/SegmentDestination.kt
@@ -31,7 +31,7 @@ class SegmentDestination(
 ) : DestinationPlugin() {
 
     override val key: String = "Segment.io"
-    internal val httpClient: HTTPClient = HTTPClient()
+    internal val httpClient: HTTPClient = HTTPClient(apiKey)
     internal lateinit var storage: Storage
     lateinit var flushScheduler: ScheduledExecutorService
     internal val eventCount = AtomicInteger(0)
@@ -135,7 +135,7 @@ class SegmentDestination(
         eventCount.set(0)
         for (fileUrl in fileUrls) {
             try {
-                val connection = httpClient.upload(apiHost, apiKey)
+                val connection = httpClient.upload(apiHost)
                 val file = File(fileUrl)
                 // flush is executed in a thread pool and file could have been deleted by another thread
                 if (!file.exists()) {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -56,7 +56,7 @@ fun Analytics.checkSettings() {
     analyticsScope.launch(ioDispatcher) {
         log("Fetching settings on ${Thread.currentThread().name}")
         val settingsObj: Settings? = try {
-            val connection = HTTPClient().settings(writeKey)
+            val connection = HTTPClient(writeKey).settings()
             val settingsString =
                 connection.inputStream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
             log("Fetched Settings: $settingsString")

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/Base64Utils.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/Base64Utils.kt
@@ -1,0 +1,43 @@
+package com.segment.analytics.kotlin.core.utilities
+
+// Encode string to base64
+fun encodeToBase64(str: String) = encodeToBase64(str.toByteArray())
+
+// Encode byte-array to base64
+fun encodeToBase64(bytes: ByteArray) = buildString {
+    val wData = ByteArray(3) // working data
+    var i = 0
+    while (i < bytes.size) {
+        val leftover = bytes.size - i
+        val available = if (leftover >= 3) {
+            3
+        } else {
+            leftover
+        }
+        for (j in 0 until available) {
+            wData[j] = bytes[i++]
+        }
+        for (j in 2 downTo available) {
+            wData[j] = 0 // clear out
+        }
+        // Given a 3 byte block (24 bits), encode it to 4 base64 characters
+        val chunk = ((wData[0].toInt() and 0xFF) shl 16) or
+                ((wData[1].toInt() and 0xFF) shl 8) or
+                (wData[2].toInt() and 0xFF)
+
+        // if we have too little characters in this block, we add padding
+        val padCount = (wData.size - available) * 8 / 6
+
+        // encode to base64
+        for (index in 3 downTo padCount) { // 4 base64 characters
+            val char = (chunk shr (6 * index)) and 0x3f // 0b00111111
+            append(char.base64Val())
+        }
+
+        // add padding if needed
+        repeat(padCount) { append("=") }
+    }
+}
+
+private const val ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+private fun Int.base64Val(): Char = ALPHABET[this]

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/Base64UtilsTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/Base64UtilsTest.kt
@@ -1,0 +1,21 @@
+package com.segment.analytics.kotlin.core
+
+import com.segment.analytics.kotlin.core.utilities.encodeToBase64
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Base64UtilsTest {
+
+    @Test
+    fun testBase64Encoding() {
+        assertEquals(encodeToBase64(""), "")
+        assertEquals(encodeToBase64("f"), "Zg==")
+        assertEquals(encodeToBase64("fo"), "Zm8=")
+        assertEquals(encodeToBase64("foo"), "Zm9v")
+        assertEquals(encodeToBase64("foob"), "Zm9vYg==")
+        assertEquals(encodeToBase64("fooba"), "Zm9vYmE=")
+        assertEquals(encodeToBase64("foobar"), "Zm9vYmFy")
+    }
+}

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/SegmentDestinationTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/SegmentDestinationTests.kt
@@ -196,7 +196,7 @@ class SegmentDestinationTests {
                 outputBytes = (outputStream as ByteArrayOutputStream).toByteArray()
             }
         }
-        every { anyConstructed<HTTPClient>().upload(any(), any()) } returns connection
+        every { anyConstructed<HTTPClient>().upload(any()) } returns connection
 
         assertEquals(trackEvent, destSpy.track(trackEvent))
         assertEquals(1, segmentDestination.eventCount.get())
@@ -246,7 +246,7 @@ class SegmentDestinationTests {
                 throw HTTPException(400, "", null)
             }
         }
-        every { anyConstructed<HTTPClient>().upload(any(), any()) } returns connection
+        every { anyConstructed<HTTPClient>().upload(any()) } returns connection
 
         assertEquals(trackEvent, destSpy.track(trackEvent))
         assertEquals(1, segmentDestination.eventCount.get())
@@ -284,7 +284,7 @@ class SegmentDestinationTests {
                 throw HTTPException(429, "", null)
             }
         }
-        every { anyConstructed<HTTPClient>().upload(any(), any()) } returns connection
+        every { anyConstructed<HTTPClient>().upload(any()) } returns connection
 
         assertEquals(trackEvent, destSpy.track(trackEvent))
         assertEquals(1, segmentDestination.eventCount.get())
@@ -328,7 +328,7 @@ class SegmentDestinationTests {
                 throw HTTPException(500, "", null)
             }
         }
-        every { anyConstructed<HTTPClient>().upload(any(), any()) } returns connection
+        every { anyConstructed<HTTPClient>().upload(any()) } returns connection
 
         assertEquals(trackEvent, destSpy.track(trackEvent))
         assertEquals(1, segmentDestination.eventCount.get())

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/SettingsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/SettingsTests.kt
@@ -33,7 +33,7 @@ class SettingsTests {
         )
         val httpConnection: HttpURLConnection = mockk()
         val connection = object : Connection(httpConnection, settingsStream, null) {}
-        every { anyConstructed<HTTPClient>().settings(any()) } returns connection
+        every { anyConstructed<HTTPClient>().settings() } returns connection
     }
 
     @BeforeEach


### PR DESCRIPTION
Closes #22 

Context: android pre API 26 does not implement `java.util.Base64` and recommends using `android.util.Base64` instead. I couldn't find a way to switch between the 2 implementations while supporting both android and JVM, so I wrote my own implementation of Base64 encoding. 

Additional changes: 
- change upload endpoint to use `/batch` instead of `/import`
- make httpclient stateful
- cache authHeader in httpClient to prevent base64 recomputation
- improve httpclient tests