### PR TITLE
Add new mapTransform function

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Configuration.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Configuration.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.Executors
  * @property ioDispatcher Dispatcher running IO tasks, defaults to `Dispatchers.IO`
  * @property storageProvider Provider for storage class, defaults to `ConcreteStorageProvider`
  * @property collectDeviceId collect deviceId, defaults to `false`
- * @property trackApplicationLifecycleEvents automatically track Lifecycle events, defaults to `false`
+ * @property trackApplicationLifecycleEvents automatically send track for Lifecycle events (eg: Application Opened, Application Backgrounded, etc.), defaults to `false`
  * @property useLifecycleObserver enables the use of LifecycleObserver to track Application lifecycle events. Defaults to `false`.
  * @property trackDeepLinks automatically track [Deep link][https://developer.android.com/training/app-links/deep-linking] opened based on intents, defaults to `false`
  * @property flushAt count of events at which we flush events, defaults to `20`

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/Base64Utils.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/Base64Utils.kt
@@ -3,7 +3,7 @@ package com.segment.analytics.kotlin.core.utilities
 // Encode string to base64
 fun encodeToBase64(str: String) = encodeToBase64(str.toByteArray())
 
-// Encode byte-array to base64
+// Encode byte-array to base64, this implementation is not url-safe
 fun encodeToBase64(bytes: ByteArray) = buildString {
     val wData = ByteArray(3) // working data
     var i = 0

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/JSON.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/JSON.kt
@@ -1,6 +1,5 @@
 package com.segment.analytics.kotlin.core.utilities
 
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -9,7 +8,6 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.floatOrNull
@@ -88,8 +86,7 @@ fun JsonObject.getMapSet(key: String): Set<Map<String, Any>>? {
         null
 }
 
-inline fun <reified T> asJsonElement(element: T): JsonElement = Json.encodeToJsonElement(element)
-
+// Utility function to apply key-mappings (deep traversal) and an optional value transform
 fun JsonObject.mapTransform(
     keyMapper: Map<String, String>,
     valueTransform: ((key: String, value: JsonElement) -> JsonElement)? = null

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/JSON.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/JSON.kt
@@ -105,17 +105,7 @@ fun JsonObject.mapTransform(
             // if so, lets recurse...
             newVal = value.mapTransform(keyMapper, valueTransform)
         } else if (value is JsonArray) {
-            // if it's an array, we need to see if any dictionaries are within and process
-            // those as well.
-            newVal = buildJsonArray {
-                value.forEach { item ->
-                    var newValue = item
-                    if (item is JsonObject) {
-                        newValue = item.mapTransform(keyMapper, valueTransform)
-                    }
-                    add(newValue)
-                }
-            }
+            newVal = value.mapTransform(keyMapper, valueTransform)
         }
         if (newVal !is JsonObject && valueTransform != null) {
             // it's not a dictionary apply our transform.
@@ -128,6 +118,24 @@ fun JsonObject.mapTransform(
         put(newKey, newVal)
     }
 }
+
+// Utility function to apply key-mappings (deep traversal) and an optional value transform
+fun JsonArray.mapTransform(
+    keyMapper: Map<String, String>,
+    valueTransform: ((key: String, value: JsonElement) -> JsonElement)? = null
+): JsonArray = buildJsonArray {
+    val original = this@mapTransform
+    original.forEach { item: JsonElement ->
+        var newValue = item
+        if (item is JsonObject) {
+            newValue = item.mapTransform(keyMapper, valueTransform)
+        } else if (item is JsonArray) {
+            newValue = item.mapTransform(keyMapper, valueTransform)
+        }
+        add(newValue)
+    }
+}
+
 
 // Utility function to transform keys in JsonObject. Only acts on root level keys
 fun JsonObject.transformKeys(transform: (String) -> String): JsonObject {


### PR DESCRIPTION
In our efforts to provide convenience APIs, we have added a new function `JsonObject.mapTransform(Map<String, String>,((String, JsonElement) -> JsonElement)?)` that allows you to easily map keys and transform values based on a closure. Example usage:
```kotlin
 properties.mapTransform(mapOf("x" to "y")) { newKey, value ->
    var newVal = value
    if (newKey == "y") {
        // ... do something
    }
    newVal
}
```