### PR TITLE
Wenxi/replace flush upload with channel api

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     // MAIN DEPS
     api project(':core')
-    api 'com.github.segmentio:sovran-kotlin:1.1.0'
+    api 'com.github.segmentio:sovran-kotlin:1.2.0'
     api "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'

--- a/android/src/main/java/com/segment/analytics/kotlin/android/Storage.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/Storage.kt
@@ -46,7 +46,7 @@ class AndroidStorage(
         )
     }
 
-    override fun write(key: Storage.Constants, value: String) {
+    override suspend fun write(key: Storage.Constants, value: String) {
         when (key) {
             Storage.Constants.Events -> {
                 if (value.length < MAX_PAYLOAD_SIZE) {
@@ -93,8 +93,8 @@ class AndroidStorage(
         return eventsFile.remove(filePath)
     }
 
-    override fun new() {
-        eventsFile.new()
+    override suspend fun rollover() {
+        eventsFile.rollover()
     }
 }
 

--- a/android/src/main/java/com/segment/analytics/kotlin/android/Storage.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/Storage.kt
@@ -92,6 +92,10 @@ class AndroidStorage(
     override fun removeFile(filePath: String): Boolean {
         return eventsFile.remove(filePath)
     }
+
+    override fun new() {
+        eventsFile.new()
+    }
 }
 
 object AndroidStorageProvider : StorageProvider {

--- a/android/src/main/java/com/segment/analytics/kotlin/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/plugins/AndroidLifecyclePlugin.kt
@@ -72,7 +72,7 @@ class AndroidLifecyclePlugin() : Application.ActivityLifecycleCallbacks, Default
         }
     }
 
-    private fun runOnAnalyticsThread(block: () -> Unit) = with(analytics) {
+    private fun runOnAnalyticsThread(block: suspend () -> Unit) = with(analytics) {
         analyticsScope.launch(analyticsDispatcher) {
             block()
         }
@@ -264,8 +264,10 @@ class AndroidLifecyclePlugin() : Application.ActivityLifecycleCallbacks, Default
         }
 
         // Update the recorded version.
-        storage.write(Storage.Constants.AppVersion, currentVersion)
-        storage.write(Storage.Constants.AppBuild, currentBuild)
+        runOnAnalyticsThread {
+            storage.write(Storage.Constants.AppVersion, currentVersion)
+            storage.write(Storage.Constants.AppBuild, currentBuild)
+        }
     }
 
     fun unregisterListeners() {

--- a/android/src/test/java/com/segment/analytics/kotlin/android/AndroidContextCollectorTests.kt
+++ b/android/src/test/java/com/segment/analytics/kotlin/android/AndroidContextCollectorTests.kt
@@ -8,6 +8,7 @@ import com.segment.analytics.kotlin.android.plugins.AndroidContextPlugin
 import com.segment.analytics.kotlin.android.utils.MemorySharedPreferences
 import io.mockk.every
 import io.mockk.spyk
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import org.junit.Assert.*
 import org.junit.Test
@@ -95,7 +96,7 @@ class AndroidContextCollectorTests {
     }
 
     @Test
-    fun `getDeviceId returns anonId when disabled`() {
+    fun `getDeviceId returns anonId when disabled`() = runBlocking {
         analytics.storage.write(Storage.Constants.AnonymousId, "anonId")
         val contextCollector = AndroidContextPlugin()
         contextCollector.setup(analytics)

--- a/android/src/test/java/com/segment/analytics/kotlin/android/AndroidLifecyclePluginTests.kt
+++ b/android/src/test/java/com/segment/analytics/kotlin/android/AndroidLifecyclePluginTests.kt
@@ -206,7 +206,7 @@ class AndroidLifecyclePluginTests {
     }
 
     @Test
-    fun `application updated is tracked`() {
+    fun `application updated is tracked`() = runBlocking {
         analytics.configuration.trackApplicationLifecycleEvents = true
         analytics.configuration.trackDeepLinks = false
         analytics.configuration.useLifecycleObserver = false

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,7 +16,7 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     // MAIN DEPS
-    api 'com.github.segmentio:sovran-kotlin:1.1.0'
+    api 'com.github.segmentio:sovran-kotlin:1.2.0'
     api "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,9 +20,6 @@ dependencies {
     api "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
 
-    implementation "io.ktor:ktor-client-core:1.6.4"
-    implementation "io.ktor:ktor-client-cio:1.6.4"
-
     // TESTING
     repositories { mavenCentral() }
     testImplementation 'io.mockk:mockk:1.10.6'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,7 +19,9 @@ dependencies {
     api 'com.github.segmentio:sovran-kotlin:1.1.0'
     api "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.5.2'
+
+    implementation "io.ktor:ktor-client-core:1.6.4"
+    implementation "io.ktor:ktor-client-cio:1.6.4"
 
     // TESTING
     repositories { mavenCentral() }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     api 'com.github.segmentio:sovran-kotlin:1.1.0'
     api "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.5.2'
 
     // TESTING
     repositories { mavenCentral() }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
@@ -81,14 +81,7 @@ class Analytics internal constructor(
             checkSettings()
 
             if (configuration.autoAddSegmentDestination) {
-                add(
-                    SegmentDestination(
-                        configuration.writeKey,
-                        configuration.flushAt,
-                        configuration.flushInterval * 1000L,
-                        configuration.apiHost
-                    )
-                )
+                add(SegmentDestination())
             }
         }
     }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
@@ -16,12 +16,18 @@ import java.time.Duration
 import java.util.concurrent.Executors
 
 class HTTPClient(
-    private val writeKey: String,
+    writeKey: String,
     dispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
 ) {
-    internal val authHeader: String
+    internal var authHeader: String
 
     private val client: HttpClient
+
+    internal var writeKey: String = writeKey
+        set(value) {
+            field = value
+            authHeader = authorizationHeader(field)
+        }
 
     init {
         authHeader = authorizationHeader(writeKey)

--- a/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
@@ -12,7 +12,7 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.zip.GZIPOutputStream
 
-class HTTPClient(var writeKey: String) {
+class HTTPClient(private val writeKey: String) {
     internal val authHeader = authorizationHeader(writeKey)
 
     fun settings(cdnHost: String): Connection {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
@@ -12,14 +12,8 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.zip.GZIPOutputStream
 
-class HTTPClient(writeKey: String) {
-    internal var authHeader = authorizationHeader(writeKey)
-
-    internal var writeKey: String = writeKey
-        set(value) {
-            field = value
-            authHeader = authorizationHeader(field)
-        }
+class HTTPClient(var writeKey: String) {
+    internal val authHeader = authorizationHeader(writeKey)
 
     fun settings(cdnHost: String): Connection {
         val connection: HttpURLConnection =

--- a/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
@@ -54,6 +54,7 @@ class HTTPClient(
             append("Authorization", authHeader)
             append("Content-Encoding", "gzip")
         }
+        request.contentType(ContentType.Application.Json)
         request.body = FileContent(file)
 
         client.post<HttpResponse>(request).apply {
@@ -85,7 +86,6 @@ class HTTPClient(
         request.headers {
             append("User-Agent","analytics-kotlin/$LIBRARY_VERSION")
         }
-        request.contentType(ContentType.Application.Json)
 
         return request
     }
@@ -96,7 +96,6 @@ class FileContent(private val file: File): OutgoingContent.WriteChannelContent()
     override suspend fun writeTo(channel: ByteWriteChannel) {
         file.inputStream().copyTo(channel, 1024)
     }
-    override val contentType = ContentType.Application.Json
     override val contentLength: Long = file.length()
 }
 

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.serializer
+import java.io.BufferedReader
 
 @Serializable
 data class Settings(
@@ -64,7 +65,9 @@ suspend fun Analytics.checkSettings() {
     withContext(networkIODispatcher) {
         log("Fetching settings on ${Thread.currentThread().name}")
         val settingsObj: Settings? = try {
-            val settingsString = HTTPClient(writeKey).settings(cdnHost)
+            val connection = HTTPClient(writeKey).settings(cdnHost)
+            val settingsString =
+                connection.inputStream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
             log("Fetched Settings: $settingsString")
             LenientJson.decodeFromString(settingsString)
         } catch (ex: Exception) {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -13,7 +13,6 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.serializer
-import java.io.BufferedReader
 
 @Serializable
 data class Settings(
@@ -59,9 +58,7 @@ suspend fun Analytics.checkSettings() {
     withContext(networkIODispatcher) {
         log("Fetching settings on ${Thread.currentThread().name}")
         val settingsObj: Settings? = try {
-            val connection = HTTPClient(writeKey).settings(cdnHost)
-            val settingsString =
-                connection.inputStream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
+            val settingsString = HTTPClient(writeKey).settings(cdnHost)
             log("Fetched Settings: $settingsString")
             LenientJson.decodeFromString(settingsString)
         } catch (ex: Exception) {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -52,6 +52,12 @@ suspend fun Analytics.checkSettings() {
     val writeKey = configuration.writeKey
     val cdnHost = configuration.cdnHost
 
+    // check current system state to determine whether it's initial or refresh
+    val systemState = store.currentState(System::class)
+    val hasSettings = systemState?.settings?.integrations != null &&
+            systemState.settings?.plan != null
+    val updateType = if (hasSettings) Plugin.UpdateType.Refresh else Plugin.UpdateType.Initial
+
     // stop things; queue in case our settings have changed.
     store.dispatch(System.ToggleRunningAction(running = false), System::class)
 
@@ -65,23 +71,15 @@ suspend fun Analytics.checkSettings() {
             log(message = "${ex.message}: failed to fetch settings", type = LogType.ERROR)
             null
         }
-        settingsObj?.let {
-            log("Dispatching update settings on ${Thread.currentThread().name}")
 
-            // check current system state to determine whether it's initial or refresh
-            val systemState = store.currentState(System::class)
-            val hasSettings = systemState?.settings?.integrations != null &&
-                                systemState.settings?.plan != null
-            val updateType = if (hasSettings) Plugin.UpdateType.Refresh else Plugin.UpdateType.Initial
-
-            withContext(analyticsDispatcher) {
-                store.dispatch(System.UpdateSettingsAction(settingsObj), System::class)
-            }
-            update(settingsObj, updateType)
-        }
-
-        // we're good to go back to a running state.
         withContext(analyticsDispatcher) {
+            settingsObj?.let {
+                log("Dispatching update settings on ${Thread.currentThread().name}")
+                store.dispatch(System.UpdateSettingsAction(settingsObj), System::class)
+                update(settingsObj, updateType)
+            }
+
+            // we're good to go back to a running state.
             store.dispatch(System.ToggleRunningAction(running = true), System::class)
         }
     }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Storage.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Storage.kt
@@ -44,6 +44,13 @@ interface Storage {
     fun read(key: Constants): String?
     fun remove(key: Constants): Boolean
     fun removeFile(filePath: String): Boolean
+
+    /**
+     * Direct writes to a new file, and close the current file.
+     * This function is useful in cases such as `flush`, that
+     * we want to finish writing the current file, and have it
+     * flushed to server.
+     */
     suspend fun rollover()
 
     suspend fun userInfoUpdate(userInfo: UserInfo) {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Storage.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Storage.kt
@@ -44,6 +44,7 @@ interface Storage {
     fun read(key: Constants): String?
     fun remove(key: Constants): Boolean
     fun removeFile(filePath: String): Boolean
+    fun new()
 
     fun userInfoUpdate(userInfo: UserInfo) {
         write(Constants.AnonymousId, userInfo.anonymousId)

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Storage.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Storage.kt
@@ -40,13 +40,13 @@ interface Storage {
     }
 
     suspend fun subscribeToStore()
-    fun write(key: Constants, value: String)
+    suspend fun write(key: Constants, value: String)
     fun read(key: Constants): String?
     fun remove(key: Constants): Boolean
     fun removeFile(filePath: String): Boolean
-    fun new()
+    suspend fun rollover()
 
-    fun userInfoUpdate(userInfo: UserInfo) {
+    suspend fun userInfoUpdate(userInfo: UserInfo) {
         write(Constants.AnonymousId, userInfo.anonymousId)
         userInfo.userId?.let { write(Constants.UserId, it) }
         userInfo.traits?.let {
@@ -57,7 +57,7 @@ interface Storage {
         }
     }
 
-    fun systemUpdate(system: System) {
+    suspend fun systemUpdate(system: System) {
         system.settings?.let {
             write(
                 Constants.Settings,

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
@@ -1,0 +1,181 @@
+package com.segment.analytics.kotlin.core.platform
+
+import com.segment.analytics.kotlin.core.*
+import com.segment.analytics.kotlin.core.platform.plugins.LogType
+import com.segment.analytics.kotlin.core.platform.plugins.log
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.channels.consumeEach
+import java.lang.Exception
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.io.path.Path
+import kotlin.io.path.deleteIfExists
+
+class EventPipeline(
+    private val analytics: Analytics,
+    private val logTag: String,
+    apiKey: String,
+    private val flushCount: Int = 20,
+    private val flushIntervalInMillis: Long = 30_000, // 30s
+    var apiHost: String = Constants.DEFAULT_API_HOST
+) {
+
+    private val writeChannel: Channel<String>
+
+    private val uploadChannel: Channel<List<String>>
+
+    private val cleanupChannel: Channel<Path>
+
+    private val eventCount: AtomicInteger = AtomicInteger(0)
+
+    private val httpClient: HTTPClient = HTTPClient(apiKey)
+
+    private val storage get() = analytics.storage
+
+    private val scope get() = analytics.analyticsScope
+
+    private var running: Boolean
+
+    var apiKey: String = apiKey
+        set(value) {
+            field = value
+            httpClient.writeKey = field
+        }
+
+    init {
+        running = false
+
+        writeChannel = Channel(UNLIMITED)
+        uploadChannel = Channel(UNLIMITED)
+        cleanupChannel = Channel()
+
+        registerShutdownHook()
+    }
+
+    fun put(event: String) {
+        writeChannel.trySend(event)
+    }
+
+    fun flush() {
+        val eventFilePaths = parseFilePaths(storage.read(Storage.Constants.Events))
+        if (eventFilePaths.isNotEmpty()) {
+            uploadChannel.trySend(eventFilePaths)
+        }
+    }
+
+    fun start() {
+        running = true
+        schedule()
+        write()
+        upload()
+        cleanup()
+    }
+
+    fun stop() {
+        cleanupChannel.cancel()
+        uploadChannel.cancel()
+        writeChannel.cancel()
+        running = false
+    }
+
+    private fun write() = scope.launch(analytics.fileIODispatcher) {
+        for (event in writeChannel) {
+            // write to storage
+            storage.write(Storage.Constants.Events, event)
+
+            // if flush condition met, generate paths
+            if (eventCount.incrementAndGet() >= flushCount) {
+                eventCount.set(0)
+                val fileUrls = parseFilePaths(storage.read(Storage.Constants.Events))
+                uploadChannel.send(fileUrls)
+            }
+        }
+    }
+
+    private fun upload() = scope.launch(analytics.networkIODispatcher) {
+        for (fileUrlList in uploadChannel) {
+            analytics.log("$logTag performing flush")
+
+            for (url in fileUrlList) {
+                // upload event file
+                val path = Path(url)
+                var shouldCleanup = true
+
+                try {
+                    httpClient.upload(apiHost, path)
+                    analytics.log("$logTag uploaded $path")
+                } catch (e: Exception) {
+                    shouldCleanup = handleUploadException(e, path)
+                }
+
+                if (shouldCleanup) {
+                    // send path for deletion
+                    cleanupChannel.send(path)
+                }
+            }
+        }
+    }
+
+    private fun cleanup() = scope.launch(Dispatchers.IO) {
+        cleanupChannel.consumeEach {
+            it.deleteIfExists()
+        }
+    }
+
+    private fun schedule() = scope.launch(analytics.fileIODispatcher) {
+        if (flushIntervalInMillis > 0) {
+            while (isActive && running) {
+                flush()
+
+                // use delay to do periodical task
+                // this is doable in coroutine, since delay only suspends, allowing thread to
+                // do other work and then come back. see:
+                // https://github.com/Kotlin/kotlinx.coroutines/issues/1632#issuecomment-545693827
+                delay(flushIntervalInMillis)
+            }
+        }
+    }
+
+    private fun handleUploadException(e: Exception, path: Path): Boolean {
+        var shouldCleanup = false
+        if (e is HTTPException) {
+            analytics.log("$logTag exception while uploading, ${e.message}")
+            if (e.is4xx() && e.responseCode != 429) {
+                // Simply log and proceed to remove the rejected payloads from the queue.
+                analytics.log(
+                    message = "Payloads were rejected by server. Marked for removal.",
+                    type = LogType.ERROR
+                )
+                shouldCleanup = true
+            } else {
+                analytics.log(
+                    message = "Error while uploading payloads",
+                    type = LogType.ERROR
+                )
+            }
+        }
+        else {
+            analytics.log(
+                """
+                    | Error uploading events from batch file
+                    | fileUrl="$path"
+                    | msg=${e.message}
+                """.trimMargin(), type = LogType.ERROR
+            )
+            e.printStackTrace()
+        }
+
+        return shouldCleanup
+    }
+
+    private fun registerShutdownHook() {
+        // close the stream if the app shuts down
+        Runtime.getRuntime().addShutdownHook(object : Thread() {
+            override fun run() {
+                this@EventPipeline.stop()
+            }
+        })
+    }
+}

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
@@ -75,8 +75,11 @@ internal class EventPipeline(
         for (event in writeChannel) {
             // write to storage
             val isPoison = (event == FLUSH_POISON)
-            if (!isPoison) {
+            if (!isPoison) try {
                 storage.write(Storage.Constants.Events, event)
+            }
+            catch (e : Exception) {
+                analytics.log("Error adding payload: $event", type = LogType.ERROR)
             }
 
             // if flush condition met, generate paths

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
@@ -103,8 +103,9 @@ class EventPipeline(
             for (url in fileUrlList) {
                 // upload event file
                 val file = File(url)
-                var shouldCleanup = true
+                if (!file.exists()) continue
 
+                var shouldCleanup = true
                 try {
                     httpClient.upload(apiHost, file)
                     analytics.log("$logTag uploaded $file")
@@ -161,6 +162,15 @@ class EventPipeline(
                     type = LogType.ERROR
                 )
             }
+        }
+        else if (e is FileIOException) {
+            analytics.log(
+                """
+                    | Error uploading events from batch file
+                    | fileUrl="${file.path}"
+                    | msg=${e.message}
+                """.trimMargin(), type = LogType.INFO
+            )
         }
         else {
             analytics.log(

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
@@ -33,12 +33,13 @@ internal class EventPipeline(
 
     private val scope get() = analytics.analyticsScope
 
-    private var running: Boolean
+    var running: Boolean
+        private set
 
     companion object {
-        private const val FLUSH_POISON = "#!flush"
+        internal const val FLUSH_POISON = "#!flush"
 
-        private const val UPLOAD_SIG = "#!upload"
+        internal const val UPLOAD_SIG = "#!upload"
     }
 
     init {
@@ -124,7 +125,7 @@ internal class EventPipeline(
                 }
 
                 if (shouldCleanup) {
-                    file.delete()
+                    storage.removeFile(file.path)
                 }
             }
         }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
@@ -99,6 +99,4 @@ class SegmentDestination : DestinationPlugin() {
     override fun flush() {
         pipeline.flush()
     }
-
-
 }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
@@ -90,7 +90,6 @@ class SegmentDestination : DestinationPlugin() {
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         if (settings.isDestinationEnabled(key)) {
             settings.destinationSettings<SegmentSettings>(key)?.let {
-                pipeline.apiKey = it.apiKey
                 pipeline.apiHost = it.apiHost
             }
         }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
@@ -2,23 +2,16 @@ package com.segment.analytics.kotlin.core.platform.plugins
 
 import com.segment.analytics.kotlin.core.*
 import com.segment.analytics.kotlin.core.Constants.DEFAULT_API_HOST
-import com.segment.analytics.kotlin.core.HTTPException
 import com.segment.analytics.kotlin.core.platform.DestinationPlugin
+import com.segment.analytics.kotlin.core.platform.EventPipeline
 import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.utilities.EncodeDefaultsJson
-import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import java.io.File
-import java.io.FileInputStream
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 
 @Serializable
 data class SegmentSettings(
@@ -31,20 +24,13 @@ data class SegmentSettings(
  * How it works
  * - Plugin receives `apiHost` settings
  * - We store events into a file with the batch api format (@link {https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/#batch})
- * - We upload events on ioDispatcher using the batch api
+ * - We upload events on a dedicated thread using the batch api
  */
-class SegmentDestination(
-    private var apiKey: String,
-    private val flushCount: Int = 20,
-    private val flushIntervalInMillis: Long = 30 * 1000, // 30s
-    private var apiHost: String = DEFAULT_API_HOST
-) : DestinationPlugin() {
+class SegmentDestination : DestinationPlugin() {
+
+    private lateinit var pipeline: EventPipeline
 
     override val key: String = "Segment.io"
-    internal val httpClient: HTTPClient = HTTPClient(apiKey)
-    internal  val storage get() = analytics.storage
-    lateinit var flushScheduler: ScheduledExecutorService
-    internal val eventCount = AtomicInteger(0)
 
     override fun track(payload: TrackEvent): BaseEvent {
         enqueue(payload)
@@ -81,114 +67,38 @@ class SegmentDestination(
 
         val stringVal = Json.encodeToString(jsonVal)
         analytics.log("$key running $stringVal")
-        try {
-            storage.write(Storage.Constants.Events, stringVal)
-            if (eventCount.incrementAndGet() >= flushCount) {
-                flush()
-            }
-        } catch (ex: Exception) {
-            analytics.log("Error adding payload", type = LogType.ERROR, event = payload)
-        }
+
+        pipeline.put(stringVal)
     }
 
     override fun setup(analytics: Analytics) {
         super.setup(analytics)
 
-        // register timer for flush interval
-        flushScheduler = Executors.newScheduledThreadPool(1)
-        if (flushIntervalInMillis > 0) {
-            var initialDelay = flushIntervalInMillis
-
-            // If we have events in queue flush them
-            val eventFilePaths =
-                parseFilePaths(storage.read(Storage.Constants.Events))
-            if (eventFilePaths.isNotEmpty()) {
-                initialDelay = 0
-            }
-
-            flushScheduler.scheduleAtFixedRate(
-                ::flush,
-                initialDelay,
-                flushIntervalInMillis,
-                TimeUnit.MILLISECONDS
+        with(analytics) {
+            pipeline = EventPipeline(
+                analytics,
+                key,
+                configuration.writeKey,
+                configuration.flushAt,
+                configuration.flushInterval * 1000L,
+                configuration.apiHost
             )
+            pipeline.start()
         }
     }
 
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         if (settings.isDestinationEnabled(key)) {
             settings.destinationSettings<SegmentSettings>(key)?.let {
-                apiKey = it.apiKey
-                apiHost = it.apiHost
+                pipeline.apiKey = it.apiKey
+                pipeline.apiHost = it.apiHost
             }
         }
     }
 
     override fun flush() {
-        analytics.run {
-            analyticsScope.launch(networkIODispatcher) {
-                performFlush()
-            }
-        }
+        pipeline.flush()
     }
 
-    private fun performFlush() {
-        if (eventCount.get() < 1) {
-            return
-        }
-        analytics.log("$key performing flush")
-        val fileUrls = parseFilePaths(storage.read(Storage.Constants.Events))
-        if (fileUrls.isEmpty()) {
-            analytics.log("No events to upload")
-            return
-        }
-        eventCount.set(0)
-        for (fileUrl in fileUrls) {
-            try {
-                val connection = httpClient.upload(apiHost)
-                val file = File(fileUrl)
-                // flush is executed in a thread pool and file could have been deleted by another thread
-                if (!file.exists()) {
-                    continue
-                }
-                connection.outputStream?.let {
-                    // Write the payloads into the OutputStream.
-                    val fileInputStream = FileInputStream(file)
-                    fileInputStream.copyTo(connection.outputStream)
-                    fileInputStream.close()
-                    connection.outputStream.close()
 
-                    // Upload the payloads.
-                    connection.close()
-                }
-                // Cleanup uploaded payloads
-                storage.removeFile(fileUrl)
-                analytics.log("$key uploaded $fileUrl")
-            } catch (e: HTTPException) {
-                analytics.log("$key exception while uploading, ${e.message}")
-                if (e.is4xx() && e.responseCode != 429) {
-                    // Simply log and proceed to remove the rejected payloads from the queue.
-                    analytics.log(
-                        message = "Payloads were rejected by server. Marked for removal.",
-                        type = LogType.ERROR
-                    )
-                    storage.removeFile(fileUrl)
-                } else {
-                    analytics.log(
-                        message = "Error while uploading payloads",
-                        type = LogType.ERROR
-                    )
-                }
-            } catch (e: Exception) {
-                analytics.log(
-                    """
-                    | Error uploading events from batch file
-                    | fileUrl="$fileUrl"
-                    | msg=${e.message}
-                """.trimMargin(), type = LogType.ERROR
-                )
-                e.printStackTrace()
-            }
-        }
-    }
 }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventsFileManager.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventsFileManager.kt
@@ -69,7 +69,7 @@ class EventsFileManager(
 
         // check if file is at capacity
         if (file.length() > MAX_FILE_SIZE) {
-            finish(file)
+            finish()
             // update index
             file = currentFile()
             file.createNewFile()
@@ -94,7 +94,8 @@ class EventsFileManager(
      * closes the current file, and returns a comma-separated list of file paths that are not yet uploaded
      */
     fun read(): List<String> {
-        finish(currentFile())
+        finish()
+        // we need to filter out .temp file, since its operating on the writing thread
         val fileList = directory.listFiles { _, name ->
             name.contains(writeKey) && !name.endsWith(".tmp")
         } ?: emptyArray()
@@ -116,7 +117,8 @@ class EventsFileManager(
         writeToFile(contents.toByteArray(), file)
     }
 
-    private fun finish(file: File) {
+    private fun finish() {
+        val file = currentFile()
         if (!file.exists()) {
             // if tmp file doesnt exist then we dont need to do anything
             return

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventsFileManager.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventsFileManager.kt
@@ -69,7 +69,7 @@ class EventsFileManager(
 
         // check if file is at capacity
         if (file.length() > MAX_FILE_SIZE) {
-            finish()
+            new()
             // update index
             file = currentFile()
             file.createNewFile()
@@ -91,10 +91,9 @@ class EventsFileManager(
     }
 
     /**
-     * closes the current file, and returns a comma-separated list of file paths that are not yet uploaded
+     * Returns a comma-separated list of file paths that are not yet uploaded
      */
     fun read(): List<String> {
-        finish()
         // we need to filter out .temp file, since its operating on the writing thread
         val fileList = directory.listFiles { _, name ->
             name.contains(writeKey) && !name.endsWith(".tmp")
@@ -117,7 +116,11 @@ class EventsFileManager(
         writeToFile(contents.toByteArray(), file)
     }
 
-    private fun finish() {
+    /**
+     * closes current file, and increase the index
+     * so next write go to a new file
+     */
+    fun new() {
         val file = currentFile()
         if (!file.exists()) {
             // if tmp file doesnt exist then we dont need to do anything

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventsFileManager.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventsFileManager.kt
@@ -134,7 +134,7 @@ class EventsFileManager(
 
     // return the current tmp file
     private fun currentFile(): File {
-        curFile = curFile?.run {
+        curFile = curFile ?: run {
             val index = kvs.getInt(fileIndexKey, 0)
             File(directory, "$writeKey-$index.tmp")
         }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventsFileManager.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventsFileManager.kt
@@ -39,9 +39,12 @@ class EventsFileManager(
 
     init {
         createDirectory(directory)
+        registerShutdownHook()
     }
 
     private val fileIndexKey = "segment.events.file.index.$writeKey"
+
+    private var os: FileOutputStream? = null
 
     companion object {
         const val MAX_FILE_SIZE = 475_000 // 475KB
@@ -120,6 +123,8 @@ class EventsFileManager(
         val contents = """],"sentAt":"${Instant.now()}"}"""
         writeToFile(contents.toByteArray(), file)
         file.renameTo(File(directory, file.nameWithoutExtension))
+        os?.close()
+        os = null
         incrementFileIndex()
     }
 
@@ -132,10 +137,20 @@ class EventsFileManager(
     // Atomic write to underlying file
     // TODO make atomic
     private fun writeToFile(content: ByteArray, file: File) {
-        val os = FileOutputStream(file, true)
-        os.write(content)
-        os.flush()
-        os.close()
+        os = os ?: FileOutputStream(file, true)
+        os?.run {
+            write(content)
+            flush()
+        }
+    }
+
+    private fun registerShutdownHook() {
+        // close the stream if the app shuts down
+        Runtime.getRuntime().addShutdownHook(object : Thread() {
+            override fun run() {
+                os?.close()
+            }
+        })
     }
 }
 

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/StorageImpl.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/StorageImpl.kt
@@ -49,7 +49,7 @@ class StorageImpl(
         )
     }
 
-    override fun write(key: Storage.Constants, value: String) {
+    override suspend fun write(key: Storage.Constants, value: String) {
         when (key) {
             Storage.Constants.Events -> {
                 if (value.length < MAX_PAYLOAD_SIZE) {
@@ -93,8 +93,8 @@ class StorageImpl(
         return eventsFile.remove(filePath)
     }
 
-    override fun new() {
-        eventsFile.new()
+    override suspend fun rollover() {
+        eventsFile.rollover()
     }
 
 }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/StorageImpl.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/StorageImpl.kt
@@ -93,6 +93,10 @@ class StorageImpl(
         return eventsFile.remove(filePath)
     }
 
+    override fun new() {
+        eventsFile.new()
+    }
+
 }
 
 object ConcreteStorageProvider : StorageProvider {

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/EventPipelineTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/EventPipelineTest.kt
@@ -1,0 +1,161 @@
+package com.segment.analytics.kotlin.core.platform
+
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.HTTPClient
+import com.segment.analytics.kotlin.core.HTTPException
+import com.segment.analytics.kotlin.core.Storage
+import com.segment.analytics.kotlin.core.utilities.ConcreteStorageProvider
+import com.segment.analytics.kotlin.core.utils.mockAnalytics
+import io.mockk.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+internal class EventPipelineTest {
+
+    private lateinit var pipeline: EventPipeline
+
+    private lateinit var analytics: Analytics
+
+    private lateinit var storage: Storage
+
+    @BeforeEach
+    internal fun setUp() {
+        MockKAnnotations.init(this)
+        mockkConstructor(HTTPClient::class)
+        mockkConstructor(File::class)
+
+        analytics = mockAnalytics()
+        storage = spyk(ConcreteStorageProvider.getStorage(
+            analytics,
+            analytics.store,
+            analytics.configuration.writeKey,
+            analytics.fileIODispatcher,
+            this))
+        every { analytics.storage } returns storage
+
+        pipeline = EventPipeline(analytics,
+            "test",
+            "123", 2, 0)
+        pipeline.start()
+    }
+
+    @Test
+    fun put() {
+        val event = "event 1"
+        pipeline.put(event)
+        coVerify(timeout = 2000) { storage.write(Storage.Constants.Events, event) }
+    }
+
+    @Test
+    fun flush() {
+        pipeline.put("event 1")
+        pipeline.put(EventPipeline.FLUSH_POISON)
+        coVerify(timeout = 2000) {
+            storage.rollover()
+            storage.read(Storage.Constants.Events)
+            anyConstructed<HTTPClient>().upload(any())
+            storage.removeFile(any())
+        }
+    }
+
+    @Test
+    fun start() {
+        assertTrue(pipeline.running)
+    }
+
+    @Test
+    fun stop() {
+        pipeline.stop()
+        assertFalse(pipeline.running)
+    }
+
+    @Test
+    fun `put more than flushCount causes flush`() {
+        pipeline.put("event 1")
+        pipeline.put("event 2")
+        coVerify(timeout = 2000) {
+            storage.rollover()
+            storage.read(Storage.Constants.Events)
+            anyConstructed<HTTPClient>().upload(any())
+            storage.removeFile(any())
+        }
+    }
+
+    @Test
+    fun `enqueuing properly handles 400 http exception`() {
+        every { anyConstructed<HTTPClient>().upload(any()) } throws HTTPException(400, "", "")
+        pipeline.put("event 1")
+        pipeline.put("event 2")
+        coVerify(timeout = 2000) {
+            storage.rollover()
+            storage.read(Storage.Constants.Events)
+            anyConstructed<HTTPClient>().upload(any())
+            storage.removeFile(any())
+        }
+    }
+
+    @Test
+    fun `enqueuing properly handles other http exception`() {
+        every { anyConstructed<HTTPClient>().upload(any()) } throws HTTPException(300, "", "")
+        pipeline.put("event 1")
+        pipeline.put("event 2")
+        coVerify(timeout = 2000) {
+            storage.rollover()
+            storage.read(Storage.Constants.Events)
+            anyConstructed<HTTPClient>().upload(any())
+        }
+        verify(exactly = 0) {
+            storage.removeFile(any())
+        }
+    }
+
+    @Test
+    fun `enqueuing properly handles other exception`() {
+        every { anyConstructed<HTTPClient>().upload(any()) } throws Exception()
+        pipeline.put("event 1")
+        pipeline.put("event 2")
+        coVerify(timeout = 2000) {
+            storage.rollover()
+            storage.read(Storage.Constants.Events)
+            anyConstructed<HTTPClient>().upload(any())
+        }
+        verify(exactly = 0) {
+            storage.removeFile(any())
+        }
+    }
+
+    @Test
+    fun `flushInterval causes regular flushing of events`() = runBlocking {
+        //restart flushScheduler
+        pipeline = EventPipeline(analytics,
+            "test",
+            "123", 2, 1_000)
+        pipeline.start()
+        pipeline.put("event 1")
+        delay(2_500)
+        coVerify(atLeast = 1, atMost = 2) {
+            storage.rollover()
+            storage.read(Storage.Constants.Events)
+            anyConstructed<HTTPClient>().upload(any())
+            storage.removeFile(any())
+        }
+    }
+
+    @Test
+    fun `flush interrupted when no event file exist`() = runBlocking {
+        pipeline.put(EventPipeline.FLUSH_POISON)
+        coVerify(exactly = 1) {
+            storage.rollover()
+            storage.read(Storage.Constants.Events)
+        }
+        verify(exactly = 0) {
+            anyConstructed<HTTPClient>().upload(any())
+            storage.removeFile(any())
+        }
+    }
+}

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestinationTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestinationTests.kt
@@ -25,6 +25,7 @@ import java.lang.Exception
 import java.net.HttpURLConnection
 import java.time.Instant
 import java.util.*
+import java.util.concurrent.atomic.AtomicBoolean
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SegmentDestinationTests {
@@ -51,12 +52,14 @@ class SegmentDestinationTests {
     @BeforeEach
     fun setup() {
         clearPersistentStorage()
-        segmentDestination = SegmentDestination("123", 2, 0)
+        segmentDestination = SegmentDestination()
 
         val config = Configuration(
             writeKey = "123",
             application = "Test",
-            storageProvider = ConcreteStorageProvider
+            storageProvider = ConcreteStorageProvider,
+            flushAt = 2,
+            flushInterval = 0
         )
         val store = spyStore(testScope, testDispatcher)
         analytics = Analytics(config, store, testScope, testDispatcher, testDispatcher)
@@ -64,7 +67,7 @@ class SegmentDestinationTests {
     }
 
     @Test
-    fun `enqueue adds event to storage`() {
+    fun `enqueue adds event to storage`() = runBlocking {
         val trackEvent = TrackEvent(
             event = "clicked",
             properties = buildJsonObject { put("behaviour", "good") })
@@ -83,9 +86,9 @@ class SegmentDestinationTests {
             (k == "userId" && v.jsonPrimitive.content.isBlank()) || (k == "traits" && v == emptyJsonObject)
         }
 
-        (analytics.storage as StorageImpl).let {
-            assertEquals(1, segmentDestination.eventCount.get())
-            val storagePath = it.eventsFile.read()[0]
+        (analytics.storage as StorageImpl).run {
+            eventsFile.rollover()
+            val storagePath = eventsFile.read()[0]
             val storageContents = File(storagePath).readText()
             assertTrue(
                 storageContents.contains(
@@ -93,27 +96,6 @@ class SegmentDestinationTests {
                 )
             )
         }
-    }
-
-    @Test
-    fun `enqueuing more than flushCount causes flush`() {
-        val trackEvent = TrackEvent(
-            event = "clicked",
-            properties = buildJsonObject { put("behaviour", "good") })
-            .apply {
-                messageId = "qwerty-1234"
-                anonymousId = "anonId"
-                integrations = emptyJsonObject
-                context = emptyJsonObject
-                timestamp = epochTimestamp
-            }
-
-        val destSpy = spyk(segmentDestination)
-        assertEquals(trackEvent, destSpy.track(trackEvent))
-        assertEquals(trackEvent, destSpy.track(trackEvent))
-
-        assertEquals(0, segmentDestination.eventCount.get())
-        verify { destSpy.flush() }
     }
 
     @Test
@@ -128,75 +110,18 @@ class SegmentDestinationTests {
                 context = emptyJsonObject
                 timestamp = epochTimestamp
             }
-        var errorAddingPayload = false
+        val errorAddingPayload = spyk(AtomicBoolean(false))
         val testLogger = object : Logger() {
             override fun log(type: LogType, message: String, event: BaseEvent?) {
-                if (type == LogType.ERROR && message == "Error adding payload") {
-                    errorAddingPayload = true
+                if (type == LogType.ERROR && message.contains("Error adding payload")) {
+                    errorAddingPayload.set(true)
                 }
             }
         }
         analytics.add(testLogger)
         val destSpy = spyk(segmentDestination)
         assertEquals(trackEvent, destSpy.track(trackEvent))
-        assertTrue(errorAddingPayload)
-    }
-
-    @Test
-    fun `enqueuing properly handles exception`() {
-        val trackEvent = TrackEvent(
-            event = "clicked",
-            properties = buildJsonObject { put("behaviour", "good") })
-            .apply {
-                messageId = "qwerty-1234"
-                anonymousId = "anonId"
-                integrations = emptyJsonObject
-                context = emptyJsonObject
-                timestamp = epochTimestamp
-            }
-        var errorAddingPayload = false
-        val testLogger = object : Logger() {
-            override fun log(type: LogType, message: String, event: BaseEvent?) {
-                if (type == LogType.ERROR && message == "Error adding payload") {
-                    errorAddingPayload = true
-                }
-            }
-        }
-        analytics.add(testLogger)
-
-        val destSpy = spyk(segmentDestination)
-        every { destSpy.flush() } throws Exception("test")
-        assertEquals(trackEvent, destSpy.track(trackEvent))
-        assertEquals(trackEvent, destSpy.track(trackEvent))
-
-        assertTrue(errorAddingPayload)
-    }
-
-    @Test
-    fun `flushInterval causes regular flushing of events`() = runBlocking {
-        //restart flushScheduler
-        val destination = SegmentDestination(
-            apiKey = "123",
-            flushCount = 10,
-            flushIntervalInMillis = 1_000
-        )
-        val destSpy = spyk(destination)
-        destSpy.setup(analytics)
-
-        val trackEvent = TrackEvent(
-            event = "clicked",
-            properties = buildJsonObject { put("behaviour", "good") })
-            .apply {
-                messageId = "qwerty-1234"
-                anonymousId = "anonId"
-                integrations = emptyJsonObject
-                context = emptyJsonObject
-                timestamp = epochTimestamp
-            }
-        assertEquals(trackEvent, destSpy.track(trackEvent))
-        delay(2_000)
-        delay(2_000)
-        verify(atLeast = 2, atMost = 5) { destSpy.flush() }
+        verify(timeout = 2000) { errorAddingPayload.set(true) }
     }
 
     @Test
@@ -220,17 +145,17 @@ class SegmentDestinationTests {
 
         val httpConnection: HttpURLConnection = mockk()
         var outputBytes: ByteArray = byteArrayOf()
-        val connection = object : Connection(httpConnection, null, ByteArrayOutputStream()) {
+        val connection = spyk(object : Connection(httpConnection, null, ByteArrayOutputStream()) {
             override fun close() {
                 outputBytes = (outputStream as ByteArrayOutputStream).toByteArray()
             }
-        }
+        })
         every { anyConstructed<HTTPClient>().upload(any()) } returns connection
 
         assertEquals(trackEvent, destSpy.track(trackEvent))
-        assertEquals(1, segmentDestination.eventCount.get())
         destSpy.flush()
 
+        verify(timeout = 2000) { connection.close() }
         with(String(outputBytes)) {
             val contentsJson: JsonObject = Json.decodeFromString(this)
             assertEquals(2, contentsJson.size)
@@ -243,7 +168,6 @@ class SegmentDestinationTests {
             assertEquals(trackEvent, eventInFile2)
         }
 
-        assertEquals(0, segmentDestination.eventCount.get())
     }
 
     @Test
@@ -258,11 +182,11 @@ class SegmentDestinationTests {
                 context = emptyJsonObject
                 timestamp = epochTimestamp
             }
-        var payloadsRejected = false
+        val payloadsRejected = spyk(AtomicBoolean(false))
         val testLogger = object : Logger() {
             override fun log(type: LogType, message: String, event: BaseEvent?) {
                 if (type == LogType.ERROR && message == "Payloads were rejected by server. Marked for removal.") {
-                    payloadsRejected = true
+                    payloadsRejected.set(true)
                 }
             }
         }
@@ -278,14 +202,12 @@ class SegmentDestinationTests {
         every { anyConstructed<HTTPClient>().upload(any()) } returns connection
 
         assertEquals(trackEvent, destSpy.track(trackEvent))
-        assertEquals(1, segmentDestination.eventCount.get())
         destSpy.flush()
-        assertTrue(payloadsRejected)
-        assertEquals(0, segmentDestination.eventCount.get())
+        verify(timeout = 2000) { payloadsRejected.set(true) }
     }
 
     @Test
-    fun `flush reads events but does not delete on fail code_429`() {
+    fun `flush reads events but does not delete on fail code_429`() = runBlocking {
         val trackEvent = TrackEvent(
             event = "clicked",
             properties = buildJsonObject { put("behaviour", "good") })
@@ -296,11 +218,11 @@ class SegmentDestinationTests {
                 context = emptyJsonObject
                 timestamp = epochTimestamp
             }
-        var errorUploading = false
+        val errorUploading = spyk(AtomicBoolean(false))
         val testLogger = object : Logger() {
             override fun log(type: LogType, message: String, event: BaseEvent?) {
                 if (type == LogType.ERROR && message == "Error while uploading payloads") {
-                    errorUploading = true
+                    errorUploading.set(true)
                 }
             }
         }
@@ -316,20 +238,17 @@ class SegmentDestinationTests {
         every { anyConstructed<HTTPClient>().upload(any()) } returns connection
 
         assertEquals(trackEvent, destSpy.track(trackEvent))
-        assertEquals(1, segmentDestination.eventCount.get())
         destSpy.flush()
-        assertTrue(errorUploading)
-        (analytics.storage as StorageImpl).let {
-            // queued event count gets cleared
-            assertEquals(0, segmentDestination.eventCount.get())
-
+        verify(timeout = 2000) { errorUploading.set(true) }
+        (analytics.storage as StorageImpl).run {
             // batch file doesnt get deleted
-            assertEquals(1, it.eventsFile.read().size)
+            eventsFile.rollover()
+            assertEquals(1, eventsFile.read().size)
         }
     }
 
     @Test
-    fun `flush reads events but does not delete on fail code_500`() {
+    fun `flush reads events but does not delete on fail code_500`() = runBlocking {
         val trackEvent = TrackEvent(
             event = "clicked",
             properties = buildJsonObject { put("behaviour", "good") })
@@ -340,11 +259,11 @@ class SegmentDestinationTests {
                 context = emptyJsonObject
                 timestamp = epochTimestamp
             }
-        var errorUploading = false
+        val errorUploading = spyk(AtomicBoolean(false))
         val testLogger = object : Logger() {
             override fun log(type: LogType, message: String, event: BaseEvent?) {
                 if (type == LogType.ERROR && message == "Error while uploading payloads") {
-                    errorUploading = true
+                    errorUploading.set(true)
                 }
             }
         }
@@ -360,15 +279,12 @@ class SegmentDestinationTests {
         every { anyConstructed<HTTPClient>().upload(any()) } returns connection
 
         assertEquals(trackEvent, destSpy.track(trackEvent))
-        assertEquals(1, segmentDestination.eventCount.get())
         destSpy.flush()
-        assertTrue(errorUploading)
-        (analytics.storage as StorageImpl).let {
-            // queued event count gets cleared
-            assertEquals(0, segmentDestination.eventCount.get())
-
+        verify(timeout = 2000) { errorUploading.set(true) }
+        (analytics.storage as StorageImpl).run {
             // batch file doesnt get deleted
-            assertEquals(1, it.eventsFile.read().size)
+            eventsFile.rollover()
+            assertEquals(1, eventsFile.read().size)
         }
     }
 
@@ -384,11 +300,11 @@ class SegmentDestinationTests {
                 context = emptyJsonObject
                 timestamp = epochTimestamp
             }
-        var exceptionUploading = false
+        val exceptionUploading = spyk(AtomicBoolean(false))
         val testLogger = object : Logger() {
             override fun log(type: LogType, message: String, event: BaseEvent?) {
                 if (type == LogType.ERROR && message.contains("test")) {
-                    exceptionUploading = true
+                    exceptionUploading.set(true)
                 }
             }
         }
@@ -398,37 +314,8 @@ class SegmentDestinationTests {
         every { anyConstructed<HTTPClient>().upload(any()) } throws Exception("test")
 
         assertEquals(trackEvent, destSpy.track(trackEvent))
-        assertEquals(1, segmentDestination.eventCount.get())
         destSpy.flush()
-        assertTrue(exceptionUploading)
-    }
 
-    @Test
-    fun `flush interrupted when no event file exist`() {
-        val trackEvent = TrackEvent(
-            event = "clicked",
-            properties = buildJsonObject { put("behaviour", "good") })
-            .apply {
-                messageId = "qwerty-1234"
-                anonymousId = "anonId"
-                integrations = emptyJsonObject
-                context = emptyJsonObject
-                timestamp = epochTimestamp
-            }
-        var interrupted = false
-        val testLogger = object : Logger() {
-            override fun log(type: LogType, message: String, event: BaseEvent?) {
-                if (type == LogType.INFO && message == "No events to upload") {
-                    interrupted = true
-                }
-            }
-        }
-        analytics.add(testLogger)
-        val destSpy = spyk(segmentDestination)
-        destSpy.track(trackEvent)
-        analytics.storage.read(Storage.Constants.Events)?.let { analytics.storage.removeFile(it) }
-
-        destSpy.flush()
-        assertTrue(interrupted)
+        verify(timeout = 2000) { exceptionUploading.set(true) }
     }
 }

--- a/samples/kotlin-jvm-app/src/main/kotlin/main.kt
+++ b/samples/kotlin-jvm-app/src/main/kotlin/main.kt
@@ -28,7 +28,6 @@ fun main(args: Array<String>) {
         analytics.flush()
         // Waiting 30s to ensure auto-flush on Segment.io destination goes through
         delay(30L * 1000)
-        analytics.find(SegmentDestination::class)?.flushScheduler?.shutdown()
     }
 }
 


### PR DESCRIPTION
* minimize the number of times of open/close file
* update `SegmentDestination` with a pipeline implementation using channel api
* make `analytics.flush` thread safe
* make file writing thread safe
* fix a bug when fetch settings
* update unit tests