### PR TITLE
Integrations Logic fix + Copy mechanism for payloads

### DIFF
--- a/android/src/test/java/com/segment/analytics/kotlin/android/StorageTests.kt
+++ b/android/src/test/java/com/segment/analytics/kotlin/android/StorageTests.kt
@@ -47,7 +47,8 @@ class StorageTests {
                 System(
                     configuration = Configuration("123"),
                     settings = Settings(),
-                    false
+                    running = false,
+                    initialSettingsDispatched = false
                 )
             )
 
@@ -102,7 +103,8 @@ class StorageTests {
                             plan = emptyJsonObject,
                             edgeFunction = emptyJsonObject
                         ),
-                        false
+                        running = false,
+                        initialSettingsDispatched = false
                     )
                 }
             }

--- a/android/src/test/java/com/segment/analytics/kotlin/android/StorageTests.kt
+++ b/android/src/test/java/com/segment/analytics/kotlin/android/StorageTests.kt
@@ -46,7 +46,6 @@ class StorageTests {
             store.provide(
                 System(
                     configuration = Configuration("123"),
-                    integrations = emptyJsonObject,
                     settings = Settings(),
                     false
                 )
@@ -89,7 +88,6 @@ class StorageTests {
                 override fun reduce(state: System): System {
                     return System(
                         configuration = state.configuration,
-                        integrations = state.integrations,
                         settings = Settings(
                             integrations = buildJsonObject {
                                 put(

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
@@ -382,11 +382,6 @@ class Analytics internal constructor(
      */
     fun add(plugin: Plugin): Analytics {
         this.timeline.add(plugin)
-        if (plugin is DestinationPlugin && plugin !is SegmentDestination) {
-            analyticsScope.launch(analyticsDispatcher) {
-                store.dispatch(System.AddIntegrationAction(plugin.key), System::class)
-            }
-        }
         return this
     }
 
@@ -412,11 +407,6 @@ class Analytics internal constructor(
      */
     fun remove(plugin: Plugin): Analytics {
         this.timeline.remove(plugin)
-        if (plugin is DestinationPlugin && plugin !is SegmentDestination) {
-            analyticsScope.launch(analyticsDispatcher) {
-                store.dispatch(System.RemoveIntegrationAction(plugin.key), System::class)
-            }
-        }
         return this
     }
 
@@ -502,6 +492,24 @@ class Analytics internal constructor(
         return traitsAsync()?.let {
             decodeFromJsonElement(deserializationStrategy, it)
         }
+    }
+
+    /**
+     * Retrieve the settings  in a blocking way.
+     * Note: this method invokes `runBlocking` internal, it's not recommended to be used
+     * in coroutines.
+     */
+    @BlockingApi
+    fun settings(): Settings? = runBlocking {
+        settingsAsync()
+    }
+
+    /**
+     * Retrieve the settings
+     */
+    suspend fun settingsAsync(): Settings? {
+        val system = store.currentState(System::class)
+        return system?.settings
     }
 }
 

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Events.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Events.kt
@@ -90,7 +90,7 @@ sealed class BaseEvent {
         val userInfo = store.currentState(UserInfo::class) ?: return
 
         this.anonymousId = userInfo.anonymousId
-        this.integrations = system.integrations ?: emptyJsonObject
+        this.integrations = emptyJsonObject
 
         if (this.userId.isBlank()) {
             // attach system userId if present

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Events.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Events.kt
@@ -86,7 +86,6 @@ sealed class BaseEvent {
     }
 
     internal suspend fun applyBaseEventData(store: Store) {
-        val system = store.currentState(System::class) ?: return
         val userInfo = store.currentState(UserInfo::class) ?: return
 
         this.anonymousId = userInfo.anonymousId
@@ -96,6 +95,60 @@ sealed class BaseEvent {
             // attach system userId if present
             this.userId = userInfo.userId ?: ""
         }
+    }
+
+    // Create a shallow copy of this event payload
+    fun <T : BaseEvent> copy(): T {
+        val original = this
+        val copy = when (this) {
+            is AliasEvent -> AliasEvent(userId = this.userId, previousId = this.previousId)
+            is GroupEvent -> GroupEvent(groupId = this.groupId, traits = this.traits)
+            is IdentifyEvent -> IdentifyEvent(userId = this.userId, traits = this.traits)
+            is ScreenEvent -> ScreenEvent(
+                name = this.name,
+                category = this.category,
+                properties = this.properties
+            )
+            is TrackEvent -> TrackEvent(event = this.event, properties = this.properties)
+        }.apply {
+//            type = original.type
+            anonymousId = original.anonymousId
+            messageId = original.messageId
+            timestamp = original.timestamp
+            context = original.context
+            integrations = original.integrations
+            userId = original.userId
+        }
+        @Suppress("UNCHECKED_CAST")
+        return copy as T // This is ok because resultant type will be same as input type
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as BaseEvent
+
+        if (type != other.type) return false
+        if (anonymousId != other.anonymousId) return false
+        if (messageId != other.messageId) return false
+        if (timestamp != other.timestamp) return false
+        if (context != other.context) return false
+        if (integrations != other.integrations) return false
+        if (userId != other.userId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = type.hashCode()
+        result = 31 * result + anonymousId.hashCode()
+        result = 31 * result + messageId.hashCode()
+        result = 31 * result + timestamp.hashCode()
+        result = 31 * result + context.hashCode()
+        result = 31 * result + integrations.hashCode()
+        result = 31 * result + userId.hashCode()
+        return result
     }
 }
 
@@ -113,6 +166,27 @@ data class TrackEvent(
     override var userId: String = ""
 
     override lateinit var timestamp: String
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as TrackEvent
+
+        if (properties != other.properties) return false
+        if (event != other.event) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + properties.hashCode()
+        result = 31 * result + event.hashCode()
+        return result
+    }
+
 }
 
 @Serializable
@@ -128,6 +202,24 @@ data class IdentifyEvent(
     override lateinit var context: AnalyticsContext
 
     override lateinit var timestamp: String
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as IdentifyEvent
+
+        if (traits != other.traits) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + traits.hashCode()
+        return result
+    }
 }
 
 @Serializable
@@ -144,6 +236,25 @@ data class GroupEvent(
     override var userId: String = ""
 
     override lateinit var timestamp: String
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as GroupEvent
+
+        if (groupId != other.groupId) return false
+        if (traits != other.traits) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + groupId.hashCode()
+        result = 31 * result + traits.hashCode()
+        return result
+    }
 }
 
 @Serializable
@@ -159,6 +270,24 @@ data class AliasEvent(
     override lateinit var context: AnalyticsContext
 
     override lateinit var timestamp: String
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as AliasEvent
+
+        if (previousId != other.previousId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + previousId.hashCode()
+        return result
+    }
 }
 
 @Serializable
@@ -176,4 +305,26 @@ data class ScreenEvent(
     override var userId: String = ""
 
     override lateinit var timestamp: String
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as ScreenEvent
+
+        if (name != other.name) return false
+        if (category != other.category) return false
+        if (properties != other.properties) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + name.hashCode()
+        result = 31 * result + category.hashCode()
+        result = 31 * result + properties.hashCode()
+        return result
+    }
 }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/State.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/State.kt
@@ -19,7 +19,8 @@ import java.util.UUID
 data class System(
     var configuration: Configuration = Configuration(""),
     var settings: Settings?,
-    var running: Boolean
+    var running: Boolean,
+    var initialSettingsDispatched: Boolean
 ) : State {
 
     companion object {
@@ -35,7 +36,8 @@ data class System(
             return System(
                 configuration = configuration,
                 settings = settings,
-                running = false
+                running = false,
+                initialSettingsDispatched = false
             )
         }
     }
@@ -45,7 +47,8 @@ data class System(
             return System(
                 state.configuration,
                 settings,
-                state.running
+                state.running,
+                state.initialSettingsDispatched
             )
         }
     }
@@ -55,14 +58,14 @@ data class System(
             return System(
                 state.configuration,
                 state.settings,
-                running
+                running,
+                state.initialSettingsDispatched
             )
         }
     }
 
     class AddDestinationToSettingsAction(
         var destinationKey: String,
-        val afterClosure: (Settings?) -> Unit
     ) : Action<System> {
         override fun reduce(state: System): System {
             val newIntegrations = buildJsonObject {
@@ -70,11 +73,24 @@ data class System(
                 put(destinationKey, true)
             }
             val newSettings = state.settings?.copy(integrations = newIntegrations)
-            afterClosure(newSettings)
             return System(
                 state.configuration,
                 newSettings,
-                state.running
+                state.running,
+                state.initialSettingsDispatched
+            )
+        }
+    }
+
+    class ToggleSettingsDispatch(
+        var dispatched: Boolean,
+    ) : Action<System> {
+        override fun reduce(state: System): System {
+            return System(
+                state.configuration,
+                state.settings,
+                state.running,
+                dispatched
             )
         }
     }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/compat/JavaAnalytics.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/compat/JavaAnalytics.kt
@@ -1,8 +1,13 @@
 package com.segment.analytics.kotlin.core.compat
 
-import com.segment.analytics.kotlin.core.*
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.Configuration
+import com.segment.analytics.kotlin.core.Properties
+import com.segment.analytics.kotlin.core.Storage
+import com.segment.analytics.kotlin.core.Traits
+import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.platform.Plugin
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.json.JsonObject
 import sovran.kotlin.Store
@@ -233,6 +238,11 @@ class JavaAnalytics private constructor() {
      * Retrieve the traits registered by a previous `identify` call
      */
     fun traits() = analytics.traits()
+
+    /**
+     * Retrieve the settings  in a blocking way.
+     */
+    fun settings() = analytics.settings()
 
     private fun setup(analytics: Analytics) {
         store = analytics.store

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Plugin.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Plugin.kt
@@ -140,12 +140,9 @@ abstract class DestinationPlugin : EventPlugin {
 
     internal fun isDestinationEnabled(event: BaseEvent?): Boolean {
         // if event payload has integration marked false then its disabled by customer
-        val customerDisabled = when (event?.integrations?.getBoolean(key)) {
-            false -> true
-            else -> false // if missing or true
-        }
+        val customerEnabled = event?.integrations?.getBoolean(key) ?: true // default to true when missing
 
         // Differs from swift, bcos kotlin can store `enabled` state. ref: https://git.io/J1bhJ
-        return (enabled && !customerDisabled)
+        return (enabled && customerEnabled)
     }
 }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Plugin.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Plugin.kt
@@ -76,7 +76,7 @@ abstract class DestinationPlugin : EventPlugin {
     override val type: Plugin.Type = Plugin.Type.Destination
     private val timeline: Timeline = Timeline()
     override lateinit var analytics: Analytics
-    internal var enabled = true
+    internal var enabled = false
     abstract val key: String
 
     override fun setup(analytics: Analytics) {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Timeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Timeline.kt
@@ -3,6 +3,7 @@ package com.segment.analytics.kotlin.core.platform
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.BaseEvent
 import com.segment.analytics.kotlin.core.System
+import com.segment.analytics.kotlin.core.utilities.getBoolean
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Timeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Timeline.kt
@@ -3,8 +3,6 @@ package com.segment.analytics.kotlin.core.platform
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.BaseEvent
 import com.segment.analytics.kotlin.core.System
-import com.segment.analytics.kotlin.core.utilities.getBoolean
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
@@ -65,7 +63,8 @@ internal class Timeline {
         plugins[plugin.type]?.add(plugin)
         with(analytics) {
             analyticsScope.launch(analyticsDispatcher) {
-                store.currentState(System::class)?.settings?.let {
+                val systemSettings = store.currentState(System::class)?.settings
+                systemSettings?.let {
                     // if we have settings then update plugin with it
                     plugin.update(it, Plugin.UpdateType.Initial)
                 }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
@@ -105,7 +105,7 @@ class SegmentDestination : DestinationPlugin() {
     }
 
     internal fun <T: BaseEvent> configureCloudDestination(event: T): T {
-        val enabledDestinations = analytics.findAll(DestinationPlugin::class).filter { it.enabled }
+        val enabledDestinations = analytics.findAll(DestinationPlugin::class).filter { it.enabled && it !is SegmentDestination }
         val merged = buildJsonObject {
             // Mark all loaded destinations as false
             enabledDestinations.forEach {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
@@ -7,12 +7,15 @@ import com.segment.analytics.kotlin.core.platform.EventPipeline
 import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.platform.plugins.logger.*
 import com.segment.analytics.kotlin.core.utilities.EncodeDefaultsJson
+import com.segment.analytics.kotlin.core.utilities.putAll
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 
 @Serializable
 data class SegmentSettings(
@@ -59,8 +62,9 @@ class SegmentDestination : DestinationPlugin() {
     }
 
     private inline fun <reified T : BaseEvent> enqueue(payload: T) {
+        val finalPayload = configureCloudDestination(payload)
         // needs to be inline reified for encoding using Json
-        val jsonVal = EncodeDefaultsJson.encodeToJsonElement(payload)
+        val jsonVal = EncodeDefaultsJson.encodeToJsonElement(finalPayload)
             .jsonObject.filterNot { (k, v) ->
                 // filter out empty userId and traits values
                 (k == "userId" && v.jsonPrimitive.content.isBlank()) || (k == "traits" && v == emptyJsonObject)
@@ -89,7 +93,7 @@ class SegmentDestination : DestinationPlugin() {
     }
 
     override fun update(settings: Settings, type: Plugin.UpdateType) {
-        if (settings.isDestinationEnabled(key)) {
+        if (settings.hasIntegrationSettings(this)) {
             settings.destinationSettings<SegmentSettings>(key)?.let {
                 pipeline.apiHost = it.apiHost
             }
@@ -98,5 +102,19 @@ class SegmentDestination : DestinationPlugin() {
 
     override fun flush() {
         pipeline.flush()
+    }
+
+    internal fun <T: BaseEvent> configureCloudDestination(event: T): T {
+        val enabledDestinations = analytics.findAll(DestinationPlugin::class).filter { it.enabled }
+        val merged = buildJsonObject {
+            // Mark all loaded destinations as false
+            enabledDestinations.forEach {
+                put(it.key, false)
+            }
+            // apply customer values; the customer is always right!
+            putAll(event.integrations)
+        }
+        event.integrations = merged
+        return event
     }
 }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
@@ -114,7 +114,9 @@ class SegmentDestination : DestinationPlugin() {
             // apply customer values; the customer is always right!
             putAll(event.integrations)
         }
-        event.integrations = merged
-        return event
+        val newEvent = event.copy<T>().apply {
+            integrations = merged
+        }
+        return newEvent
     }
 }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
@@ -98,40 +98,6 @@ class AnalyticsTests {
             assertTrue(testPlugin1.ran)
             assertTrue(testPlugin2.ran)
         }
-
-        @Test
-        fun `adding destination plugin modifies integrations object`() = runBlocking  {
-            val testPlugin1 = object : DestinationPlugin() {
-                override val key: String = "TestDestination"
-            }
-            analytics
-                .add(testPlugin1)
-
-            val system = analytics.store.currentState(System::class)
-            val curIntegrations = system?.integrations
-            assertEquals(
-                buildJsonObject {
-                    put("TestDestination", false)
-                },
-                curIntegrations
-            )
-        }
-
-        @Test
-        fun `removing destination plugin modifies integrations object`() = runBlocking  {
-            val testPlugin1 = object : DestinationPlugin() {
-                override val key: String = "TestDestination"
-            }
-            analytics.add(testPlugin1)
-            analytics.remove(testPlugin1)
-
-            val system = analytics.store.currentState(System::class)
-            val curIntegrations = system?.integrations
-            assertEquals(
-                emptyJsonObject,
-                curIntegrations
-            )
-        }
     }
 
     @Nested
@@ -165,23 +131,6 @@ class AnalyticsTests {
                 assertTrue(it.timestamp == epochTimestamp)
                 assertEquals(emptyJsonObject, it.integrations)
                 assertEquals(context, it.context)
-            }
-        }
-
-        @Test
-        fun `event gets populated with correct integrations`() = runBlocking  {
-            val mockPlugin = spyk(StubPlugin())
-            analytics.add(mockPlugin)
-            analytics.store.dispatch(System.AddIntegrationAction("plugin1"), System::class)
-            analytics.track("track", buildJsonObject { put("foo", "bar") })
-            val track = slot<TrackEvent>()
-            verify { mockPlugin.track(capture(track)) }
-            track.captured.let {
-                assertTrue(it.anonymousId.isNotBlank())
-                assertTrue(it.messageId.isNotBlank())
-                assertTrue(it.timestamp == epochTimestamp)
-                assertEquals(it.context, context)
-                assertEquals(buildJsonObject { put("plugin1", false) }, it.integrations)
             }
         }
 

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
@@ -2,18 +2,31 @@ package com.segment.analytics.kotlin.core
 
 import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.platform.plugins.ContextPlugin
-import com.segment.analytics.kotlin.core.utils.*
-import io.mockk.*
+import com.segment.analytics.kotlin.core.utils.StubPlugin
+import com.segment.analytics.kotlin.core.utils.TestRunPlugin
+import com.segment.analytics.kotlin.core.utils.clearPersistentStorage
+import com.segment.analytics.kotlin.core.utils.mockHTTPClient
+import com.segment.analytics.kotlin.core.utils.spyStore
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import java.time.Instant
-import java.util.*
+import java.util.Date
+import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AnalyticsTests {
@@ -351,6 +364,20 @@ class AnalyticsTests {
                 assertTrue(plugins.contains(child))
             }
         }
+    }
+
+    @Test
+    fun `settings fetches current Analytics Settings`() = runBlocking {
+        val settings = Settings(
+            integrations = buildJsonObject {
+                put("int1", true)
+                put("int2", false)
+            },
+            plan = emptyJsonObject,
+            edgeFunction = emptyJsonObject
+        )
+        analytics.store.dispatch(System.UpdateSettingsAction(settings), System::class)
+        assertEquals(settings, analytics.settings())
     }
 
     private fun BaseEvent.populate() = apply {

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
@@ -1,6 +1,5 @@
 package com.segment.analytics.kotlin.core
 
-import com.segment.analytics.kotlin.core.platform.DestinationPlugin
 import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.platform.plugins.ContextPlugin
 import com.segment.analytics.kotlin.core.utils.*

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
@@ -23,7 +23,7 @@ class AnalyticsTests {
     private val testScope = TestCoroutineScope(testDispatcher)
 
     private val epochTimestamp = Date(0).toInstant().toString()
-    private val context = buildJsonObject {
+    private val baseContext = buildJsonObject {
         val lib = buildJsonObject {
             put(ContextPlugin.LIBRARY_NAME_KEY, "analytics-kotlin")
             put(ContextPlugin.LIBRARY_VERSION_KEY, Constants.LIBRARY_VERSION)
@@ -112,7 +112,7 @@ class AnalyticsTests {
                 assertTrue(it.anonymousId.isNotBlank())
                 assertTrue(it.messageId.isNotBlank())
                 assertEquals(epochTimestamp, it.timestamp)
-                assertEquals(context, it.context)
+                assertEquals(baseContext, it.context)
                 assertEquals(emptyJsonObject, it.integrations)
             }
         }
@@ -129,7 +129,7 @@ class AnalyticsTests {
                 assertTrue(it.messageId.isNotBlank())
                 assertTrue(it.timestamp == epochTimestamp)
                 assertEquals(emptyJsonObject, it.integrations)
-                assertEquals(context, it.context)
+                assertEquals(baseContext, it.context)
             }
         }
 
@@ -146,7 +146,7 @@ class AnalyticsTests {
                     TrackEvent(
                         properties = buildJsonObject { put("foo", "bar") },
                         event = "track"
-                    ),
+                    ).populate(),
                     track.captured
                 )
             }
@@ -166,7 +166,7 @@ class AnalyticsTests {
                     IdentifyEvent(
                         traits = buildJsonObject { put("name", "bar") },
                         userId = "foobar"
-                    ),
+                    ).populate(),
                     identify.captured
                 )
             }
@@ -218,7 +218,7 @@ class AnalyticsTests {
                         properties = buildJsonObject { put("foo", "bar") },
                         name = "main",
                         category = "mobile"
-                    ),
+                    ).populate(),
                     screen.captured
                 )
             }
@@ -237,7 +237,7 @@ class AnalyticsTests {
                     GroupEvent(
                         traits = buildJsonObject { put("foo", "bar") },
                         groupId = "high school"
-                    ),
+                    ).populate(),
                     group.captured
                 )
             }
@@ -257,7 +257,7 @@ class AnalyticsTests {
                     AliasEvent(
                         userId = "newId",
                         previousId = "qwerty-qwerty-123"
-                    ),
+                    ).populate(),
                     alias.captured
                 )
             }
@@ -274,7 +274,7 @@ class AnalyticsTests {
                     AliasEvent(
                         userId = "newId",
                         previousId = "oldId"
-                    ),
+                    ).populate(),
                     alias.captured
                 )
             }
@@ -351,5 +351,13 @@ class AnalyticsTests {
                 assertTrue(plugins.contains(child))
             }
         }
+    }
+
+    private fun BaseEvent.populate() = apply {
+        anonymousId = "qwerty-qwerty-123"
+        messageId = "qwerty-qwerty-123"
+        timestamp = epochTimestamp
+        context = baseContext
+        integrations = emptyJsonObject
     }
 }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/EventTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/EventTests.kt
@@ -1,0 +1,131 @@
+package com.segment.analytics.kotlin.core
+
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
+import java.lang.ClassCastException
+import java.util.Date
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class EventTests {
+    private val epochTimestamp = Date(0).toInstant().toString()
+    private val defaultContext = buildJsonObject {
+        put("key1", "value")
+        put("key2", true)
+    }
+    private val defaultIntegrations = buildJsonObject {
+        put("Segment.io", false)
+        put("Mixpanel", true)
+    }
+
+    @Test
+    fun `track event can be shallow copied`() {
+        val trackEvent = TrackEvent(
+            event = "Defeated",
+            properties = buildJsonObject { put("enemy", "Joker") })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = defaultIntegrations
+                context = defaultContext
+                timestamp = epochTimestamp
+                userId = "batman"
+            }
+        val newEvent: TrackEvent = trackEvent.copy()
+        assertNotSame(newEvent, trackEvent)
+        assertTrue(newEvent == trackEvent)
+    }
+
+    @Test
+    fun `identify event can be shallow copied`() {
+        val identifyEvent = IdentifyEvent(
+            userId = "batman",
+            traits = buildJsonObject { put("softie", "false") })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = defaultIntegrations
+                context = defaultContext
+                timestamp = epochTimestamp
+            }
+        val newEvent: IdentifyEvent = identifyEvent.copy()
+        assertNotSame(newEvent, identifyEvent)
+        assertEquals(newEvent, identifyEvent)
+    }
+
+    @Test
+    fun `screen event can be shallow copied`() {
+        val screenEvent = ScreenEvent(
+            name = "Superhero Entrance",
+            category = "Entrance",
+            properties = buildJsonObject { put("applause", true) })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = defaultIntegrations
+                context = defaultContext
+                timestamp = epochTimestamp
+                userId = "batman"
+            }
+        val newEvent: ScreenEvent = screenEvent.copy()
+        assertNotSame(newEvent, screenEvent)
+        assertEquals(newEvent, screenEvent)
+    }
+
+    @Test
+    fun `group event can be shallow copied`() {
+        val groupEvent = GroupEvent(
+            groupId = "justice_league",
+            traits = buildJsonObject { put("badass", true) })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = defaultIntegrations
+                context = defaultContext
+                timestamp = epochTimestamp
+                userId = "batman"
+            }
+        val newEvent: GroupEvent = groupEvent.copy()
+        assertNotSame(newEvent, groupEvent)
+        assertEquals(newEvent, groupEvent)
+    }
+
+    @Test
+    fun `alias event can be shallow copied`() {
+        val aliasEvent = AliasEvent(
+            previousId = "batman",
+            userId = "bruce_wayne"
+        ).apply {
+            messageId = "qwerty-1234"
+            anonymousId = "anonId"
+            integrations = defaultIntegrations
+            context = defaultContext
+            timestamp = epochTimestamp
+        }
+        val newEvent: AliasEvent = aliasEvent.copy()
+        assertNotSame(newEvent, aliasEvent)
+        assertEquals(newEvent, aliasEvent)
+    }
+
+    @Test
+    fun `copy as another type fails`() {
+        val aliasEvent = AliasEvent(
+            previousId = "batman",
+            userId = "bruce_wayne"
+        ).apply {
+            messageId = "qwerty-1234"
+            anonymousId = "anonId"
+            integrations = defaultIntegrations
+            context = defaultContext
+            timestamp = epochTimestamp
+        }
+        assertThrows<ClassCastException> {
+            val track = aliasEvent.copy<TrackEvent>() // Copy as a trackEvent should throw an error
+        }
+    }
+}

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/SettingsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/SettingsTests.kt
@@ -102,8 +102,8 @@ class SettingsTests {
             }
         )
 
-        assertTrue(settings.isDestinationEnabled("Foo"))
-        assertTrue(settings.isDestinationEnabled("Bar"))
+        assertTrue(settings.hasIntegrationSettings("Foo"))
+        assertTrue(settings.hasIntegrationSettings("Bar"))
     }
 
     @Test
@@ -116,8 +116,8 @@ class SettingsTests {
             }
         )
 
-        assertTrue(settings.isDestinationEnabled("Foo"))
-        assertFalse(settings.isDestinationEnabled("Bar"))
+        assertTrue(settings.hasIntegrationSettings("Foo"))
+        assertFalse(settings.hasIntegrationSettings("Bar"))
     }
 
     @Serializable

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/compat/JavaAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/compat/JavaAnalyticsTest.kt
@@ -3,6 +3,7 @@ package com.segment.analytics.kotlin.core.compat
 import com.segment.analytics.kotlin.core.*
 import com.segment.analytics.kotlin.core.platform.DestinationPlugin
 import com.segment.analytics.kotlin.core.platform.Plugin
+import com.segment.analytics.kotlin.core.platform.plugins.ContextPlugin
 import com.segment.analytics.kotlin.core.utils.StubPlugin
 import com.segment.analytics.kotlin.core.utils.TestRunPlugin
 import com.segment.analytics.kotlin.core.utils.mockHTTPClient
@@ -18,6 +19,9 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.Date
+import java.util.UUID
 import java.util.function.Consumer
 
 internal class JavaAnalyticsTest {
@@ -27,11 +31,26 @@ internal class JavaAnalyticsTest {
     private val testDispatcher = TestCoroutineDispatcher()
     private val testScope = TestCoroutineScope(testDispatcher)
 
+    private val epochTimestamp = Date(0).toInstant().toString()
+    private val baseContext = buildJsonObject {
+        val lib = buildJsonObject {
+            put(ContextPlugin.LIBRARY_NAME_KEY, "analytics-kotlin")
+            put(ContextPlugin.LIBRARY_VERSION_KEY, Constants.LIBRARY_VERSION)
+        }
+        put(ContextPlugin.LIBRARY_KEY, lib)
+    }
+
+    init {
+        mockkStatic(Instant::class)
+        every { Instant.now() } returns Date(0).toInstant()
+        mockkStatic(UUID::class)
+        every { UUID.randomUUID().toString() } returns "qwerty-qwerty-123"
+        mockHTTPClient()
+    }
+
     @BeforeEach
     fun setup() {
-        mockHTTPClient()
-
-        val config = ConfigurationBuilder("123")
+        val config = ConfigurationBuilder("java-123")
             .setApplication("Test")
             .setAutoAddSegmentDestination(false)
             .build()
@@ -77,7 +96,7 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.track(capture(track)) }
             assertEquals(
-                TrackEvent(emptyJsonObject, event),
+                TrackEvent(emptyJsonObject, event).populate(),
                 track.captured
             )
         }
@@ -89,7 +108,7 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.track(capture(track)) }
             assertEquals(
-                TrackEvent(json, event),
+                TrackEvent(json, event).populate(),
                 track.captured
             )
         }
@@ -101,66 +120,8 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.track(capture(track)) }
             assertEquals(
-                TrackEvent(json, event),
+                TrackEvent(json, event).populate(),
                 track.captured
-            )
-        }
-    }
-
-    @Nested
-    inner class Identify {
-
-        private val userId = "foobar"
-
-        private val json = buildJsonObject { put("name", "bar") }
-
-        private lateinit var identify: CapturingSlot<IdentifyEvent>
-
-        private val serializable = object : JsonSerializable {
-            override fun serialize(): JsonObject {
-                return json
-            }
-        }
-
-        @BeforeEach
-        internal fun setUp() {
-            identify = slot()
-        }
-
-        @Test
-        fun `identify with userId`() {
-            analytics.add(mockPlugin)
-            analytics.identify(userId)
-
-            verify { mockPlugin.identify(capture(identify)) }
-            assertEquals(
-                IdentifyEvent(userId, emptyJsonObject),
-                identify.captured
-            )
-        }
-
-        @Test
-        fun `identify with userId and json`() {
-            analytics.add(mockPlugin)
-            analytics.identify(userId, json)
-
-            val identify = slot<IdentifyEvent>()
-            verify { mockPlugin.identify(capture(identify)) }
-            assertEquals(
-                IdentifyEvent(userId, json),
-                identify.captured
-            )
-        }
-
-        @Test
-        fun `identify with userId and serializable`() {
-            analytics.add(mockPlugin)
-            analytics.identify(userId, serializable)
-
-            verify { mockPlugin.identify(capture(identify)) }
-            assertEquals(
-                IdentifyEvent(userId, json),
-                identify.captured
             )
         }
     }
@@ -194,7 +155,7 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.screen(capture(screen)) }
             assertEquals(
-                ScreenEvent(title, category, emptyJsonObject),
+                ScreenEvent(title, category, emptyJsonObject).populate(),
                 screen.captured
             )
         }
@@ -206,7 +167,7 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.screen(capture(screen)) }
             assertEquals(
-                ScreenEvent(title, category, json),
+                ScreenEvent(title, category, json).populate(),
                 screen.captured
             )
         }
@@ -218,7 +179,7 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.screen(capture(screen)) }
             assertEquals(
-                ScreenEvent(title, category, json),
+                ScreenEvent(title, category, json).populate(),
                 screen.captured
             )
         }
@@ -251,7 +212,7 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.group(capture(group)) }
             assertEquals(
-                GroupEvent(groupId, emptyJsonObject),
+                GroupEvent(groupId, emptyJsonObject).populate(),
                 group.captured
             )
         }
@@ -263,7 +224,7 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.group(capture(group)) }
             assertEquals(
-                GroupEvent(groupId, json),
+                GroupEvent(groupId, json).populate(),
                 group.captured
             )
         }
@@ -275,7 +236,7 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.group(capture(group)) }
             assertEquals(
-                GroupEvent(groupId, json),
+                GroupEvent(groupId, json).populate(),
                 group.captured
             )
         }
@@ -294,6 +255,7 @@ internal class JavaAnalyticsTest {
         internal fun setUp() {
             alias = slot()
         }
+
         @Test
         fun alias() {
             analytics.add(mockPlugin)
@@ -302,11 +264,78 @@ internal class JavaAnalyticsTest {
 
             verify { mockPlugin.alias(capture(alias)) }
             assertEquals(
-                AliasEvent(newId, previousId),
+                AliasEvent(newId, previousId).populate().apply {
+                    userId = "newId"
+                },
                 alias.captured
             )
         }
     }
+
+    @Nested
+    inner class Identify {
+
+        private val userId = "foobar"
+
+        private val json = buildJsonObject { put("name", "bar") }
+
+        private lateinit var identify: CapturingSlot<IdentifyEvent>
+
+        private val serializable = object : JsonSerializable {
+            override fun serialize(): JsonObject {
+                return json
+            }
+        }
+
+        @BeforeEach
+        internal fun setUp() {
+            identify = slot()
+        }
+
+        @Test
+        fun `identify with userId`() {
+            analytics.add(mockPlugin)
+            analytics.identify(userId)
+
+            verify { mockPlugin.identify(capture(identify)) }
+            assertEquals(
+                IdentifyEvent(userId, emptyJsonObject).populate().apply {
+                    userId = this@Identify.userId
+                },
+                identify.captured
+            )
+        }
+
+        @Test
+        fun `identify with userId and json`() {
+            analytics.add(mockPlugin)
+            analytics.identify(userId, json)
+
+            val identify = slot<IdentifyEvent>()
+            verify { mockPlugin.identify(capture(identify)) }
+            assertEquals(
+                IdentifyEvent(userId, json).populate().apply {
+                    userId = this@Identify.userId
+                },
+                identify.captured
+            )
+        }
+
+        @Test
+        fun `identify with userId and serializable`() {
+            analytics.add(mockPlugin)
+            analytics.identify(userId, serializable)
+
+            verify { mockPlugin.identify(capture(identify)) }
+            assertEquals(
+                IdentifyEvent(userId, json).populate().apply {
+                    userId = this@Identify.userId
+                },
+                identify.captured
+            )
+        }
+    }
+
 
     @Nested
     inner class PluginTests {
@@ -374,7 +403,7 @@ internal class JavaAnalyticsTest {
     @Nested
     inner class Reset {
         @Test
-        fun `reset() overwrites userId and traits also resets event plugin`() = runBlocking  {
+        fun `reset() overwrites userId and traits also resets event plugin`() = runBlocking {
             val plugin = spyk(StubPlugin())
             analytics.add(plugin)
 
@@ -419,9 +448,18 @@ internal class JavaAnalyticsTest {
     }
 
     @Test
-    fun traits() = runBlocking  {
+    fun traits() = runBlocking {
         val json = buildJsonObject { put("name", "bar") }
         analytics.identify("userId", json)
         assertEquals(json, analytics.traits())
+    }
+
+    private fun BaseEvent.populate() = apply {
+        anonymousId = "qwerty-qwerty-123"
+        messageId = "qwerty-qwerty-123"
+        timestamp = epochTimestamp
+        context = baseContext
+        integrations = emptyJsonObject
+        userId = "userId"
     }
 }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/compat/JavaAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/compat/JavaAnalyticsTest.kt
@@ -454,6 +454,20 @@ internal class JavaAnalyticsTest {
         assertEquals(json, analytics.traits())
     }
 
+    @Test
+    fun settings() = runBlocking {
+        val settings = Settings(
+            integrations = buildJsonObject {
+                put("int1", true)
+                put("int2", false)
+            },
+            plan = emptyJsonObject,
+            edgeFunction = emptyJsonObject
+        )
+        analytics.store.dispatch(System.UpdateSettingsAction(settings), System::class)
+        assertEquals(settings, analytics.settings())
+    }
+
     private fun BaseEvent.populate() = apply {
         anonymousId = "qwerty-qwerty-123"
         messageId = "qwerty-qwerty-123"

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/DestinationPluginTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/DestinationPluginTests.kt
@@ -1,8 +1,11 @@
 package com.segment.analytics.kotlin.core.platform
 
-import com.segment.analytics.kotlin.core.*
-import com.segment.analytics.kotlin.core.utils.mockAnalytics
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.TrackEvent
+import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.utilities.putInContext
+import com.segment.analytics.kotlin.core.utils.mockAnalytics
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.serialization.json.buildJsonObject
@@ -11,7 +14,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.util.*
+import java.util.Date
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DestinationPluginTests {
@@ -77,8 +80,13 @@ class DestinationPluginTests {
 
     @Test
     fun `execute runs the destination timeline`() {
-        val destinationPlugin = spyk(object: DestinationPlugin() {
+        val destinationPlugin = spyk(object : DestinationPlugin() {
             override val key: String = "TestDestination"
+
+            init {
+                enabled = true
+            }
+
             override fun track(payload: TrackEvent): BaseEvent? {
                 return payload.putInContext("processedDestination", true)
             }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestinationTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestinationTests.kt
@@ -74,7 +74,7 @@ class SegmentDestinationTests {
             .apply {
                 messageId = "qwerty-1234"
                 anonymousId = "anonId"
-                integrations = emptyJsonObject
+                integrations = buildJsonObject { put("Segment.io", false) }
                 context = emptyJsonObject
                 timestamp = epochTimestamp
             }
@@ -85,6 +85,7 @@ class SegmentDestinationTests {
             // filter out empty userId and traits values
             (k == "userId" && v.jsonPrimitive.content.isBlank()) || (k == "traits" && v == emptyJsonObject)
         }
+        val expectedStringPayload = Json.encodeToString(expectedEvent)
 
         (analytics.storage as StorageImpl).run {
             eventsFile.rollover()
@@ -92,8 +93,12 @@ class SegmentDestinationTests {
             val storageContents = File(storagePath).readText()
             assertTrue(
                 storageContents.contains(
-                    Json.encodeToString(expectedEvent)
-                )
+                    expectedStringPayload
+                ),
+                """storage does not contain expected event
+                   expectedEvent = $expectedStringPayload
+                   storageContents = $storageContents
+                """.trimIndent()
             )
         }
     }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/StorageImplTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/StorageImplTest.kt
@@ -38,7 +38,6 @@ internal class StorageImplTest {
         store.provide(
             System(
                 configuration = Configuration("123"),
-                integrations = emptyJsonObject,
                 settings = Settings(),
                 false
             )
@@ -80,7 +79,6 @@ internal class StorageImplTest {
             override fun reduce(state: System): System {
                 return System(
                     configuration = state.configuration,
-                    integrations = state.integrations,
                     settings = Settings(
                         integrations = buildJsonObject {
                             put(

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/StorageImplTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/StorageImplTest.kt
@@ -39,7 +39,8 @@ internal class StorageImplTest {
             System(
                 configuration = Configuration("123"),
                 settings = Settings(),
-                false
+                running = false,
+                initialSettingsDispatched = false
             )
         )
 
@@ -93,7 +94,8 @@ internal class StorageImplTest {
                         plan = emptyJsonObject,
                         edgeFunction = emptyJsonObject
                     ),
-                    false
+                    running = false,
+                    initialSettingsDispatched = false
                 )
             }
         }

--- a/samples/kotlin-android-app-destinations/build.gradle
+++ b/samples/kotlin-android-app-destinations/build.gradle
@@ -35,13 +35,6 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
-    testOptions {
-        unitTests.returnDefaultValues = true
-        unitTests.includeAndroidResources = true
-        unitTests.all {
-            useJUnitPlatform()
-        }
-    }
 }
 
 dependencies {

--- a/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/AmplitudeSession.kt
+++ b/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/AmplitudeSession.kt
@@ -20,7 +20,7 @@ class AmplitudeSession : Plugin {
     private val fireTime: Long = 300000
 
     override fun update(settings: Settings, type:Plugin.UpdateType) {
-        active = settings.isDestinationEnabled(key)
+        active = settings.hasIntegrationSettings(key)
     }
 
     // Add the session_id to the Amplitude payload for cloud mode to handle.

--- a/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/AppsflyerDestination.kt
+++ b/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/AppsflyerDestination.kt
@@ -79,7 +79,7 @@ class AppsFlyerDestination(
 
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         super.update(settings, type)
-        if (settings.isDestinationEnabled(key)) {
+        if (settings.hasIntegrationSettings(this)) {
             analytics.log("Appsflyer Destination is enabled")
             this.settings = settings.destinationSettings(key)
             if (type == Plugin.UpdateType.Initial) {

--- a/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/ComscoreDestination.kt
+++ b/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/ComscoreDestination.kt
@@ -143,7 +143,7 @@ class ComscoreDestination(
 
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         super.update(settings, type)
-        if (settings.isDestinationEnabled(key)) {
+        if (settings.hasIntegrationSettings(this)) {
             analytics.log("Comscore Destination is enabled")
             this.settings = settings.destinationSettings(key, ComscoreSettings.serializer())
             if (type == Plugin.UpdateType.Initial) {

--- a/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/FirebaseDestination.kt
+++ b/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/FirebaseDestination.kt
@@ -81,7 +81,7 @@ class FirebaseDestination(
 ) : DestinationPlugin(), AndroidLifecycle {
 
     override val key: String = "Firebase"
-    internal lateinit var firebaseAnalytics: FirebaseAnalytics
+    internal var firebaseAnalytics: FirebaseAnalytics? = null
     private var activity: Activity? = null
 
     override fun setup(analytics: Analytics) {
@@ -105,13 +105,13 @@ class FirebaseDestination(
     override fun identify(payload: IdentifyEvent): BaseEvent {
         val userId: String = payload.userId
         val traits: JsonObject = payload.traits
-        firebaseAnalytics.setUserId(userId)
+        firebaseAnalytics?.setUserId(userId)
 
         traits.let {
             for ((traitKey, traitValue) in it) {
                 val normalizedKey = makeKey(traitKey)
                 val updatedTraitValue = traitValue.toContent().toString()
-                firebaseAnalytics.setUserProperty(normalizedKey, updatedTraitValue)
+                firebaseAnalytics?.setUserProperty(normalizedKey, updatedTraitValue)
                 analytics.log("firebaseAnalytics.setUserProperty($normalizedKey, $updatedTraitValue)")
             }
         }
@@ -128,7 +128,7 @@ class FirebaseDestination(
                 FirebaseAnalytics.Param.SCREEN_NAME to screenName,
                 FirebaseAnalytics.Param.SCREEN_CLASS to tempActivity::class.simpleName
             )
-            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle)
+            firebaseAnalytics?.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle)
             analytics.log("firebaseAnalytics.logEvent(SCREEN_VIEW, $bundle)")
         }
 
@@ -142,7 +142,7 @@ class FirebaseDestination(
 
         val bundledProperties = formatProperties(payload.properties)
 
-        firebaseAnalytics.logEvent(eventName, bundledProperties)
+        firebaseAnalytics?.logEvent(eventName, bundledProperties)
         analytics.log("firebaseAnalytics.logEvent($eventName, $bundledProperties)")
 
         return payload
@@ -159,7 +159,7 @@ class FirebaseDestination(
                 .let {
                     it.loadLabel(packageManager).toString().let { activityName ->
                         val bundle = bundleOf(FirebaseAnalytics.Param.SCREEN_NAME to activityName)
-                        firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle)
+                        firebaseAnalytics?.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle)
                         analytics.log(
                             "firebaseAnalytics.setCurrentScreen(activity, $activityName, null"
                         )

--- a/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/IntercomDestination.kt
+++ b/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/IntercomDestination.kt
@@ -69,7 +69,7 @@ class IntercomDestination(
 
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         // if we've already set up this singleton SDK, can't do it again, so skip.
-        if (type != Plugin.UpdateType.Initial) return
+        if (type != Plugin.UpdateType.Initial && this::intercom.isInitialized) return
         super.update(settings, type)
 
         settings.integrations[key]?.jsonObject?.let {

--- a/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/IntercomDestination.kt
+++ b/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/IntercomDestination.kt
@@ -69,7 +69,7 @@ class IntercomDestination(
 
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         // if we've already set up this singleton SDK, can't do it again, so skip.
-        if (type != Plugin.UpdateType.Initial && this::intercom.isInitialized) return
+        if (type != Plugin.UpdateType.Initial) return
         super.update(settings, type)
 
         settings.integrations[key]?.jsonObject?.let {

--- a/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/MixpanelDestination.kt
+++ b/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/MixpanelDestination.kt
@@ -76,7 +76,7 @@ class MixpanelDestination(
 
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         super.update(settings, type)
-        if (settings.isDestinationEnabled(key)) {
+        if (settings.hasIntegrationSettings(this)) {
             analytics.log("Mixpanel Destination is enabled")
             this.settings = settings.destinationSettings(key)
             if (type == Plugin.UpdateType.Initial) {

--- a/samples/kotlin-android-app-destinations/src/test/java/com/segment/analytics/destinations/plugins/FirebaseDestinationTest.kt
+++ b/samples/kotlin-android-app-destinations/src/test/java/com/segment/analytics/destinations/plugins/FirebaseDestinationTest.kt
@@ -1,302 +1,278 @@
 package com.segment.analytics.destinations.plugins
 
-import android.app.Activity
-import android.content.Context
-import android.content.pm.ActivityInfo
-import android.content.pm.PackageManager
-import android.os.Build
-import android.os.Bundle
-import androidx.core.os.bundleOf
-import com.google.firebase.analytics.FirebaseAnalytics
-import com.segment.analytics.kotlin.core.*
-import com.segment.analytics.kotlin.core.platform.Plugin
-import com.segment.analytics.kotlin.core.platform.plugins.logger.*
-import io.mockk.*
-import io.mockk.impl.annotations.MockK
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
-import org.junit.Assert.*
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
-class FirebaseDestinationTests {
-
-    @MockK
-    lateinit var context: Context
-
-    @MockK(relaxUnitFun = true)
-    lateinit var mockedAnalytics: Analytics
-
-    @MockK(relaxUnitFun = true)
-    lateinit var mockedFirebase: FirebaseAnalytics
-
-    private val firebaseDestination: FirebaseDestination
-
-    init {
-        MockKAnnotations.init(this)
-        mockkStatic(FirebaseAnalytics::class)
-        every { FirebaseAnalytics.getInstance(context) } returns mockedFirebase
-
-        // Need to mock log since its used in the destination
-//        mockkStatic("com.segment.analytics.kotlin.core.platform.plugins.LoggerKt")
-
-
-        firebaseDestination = FirebaseDestination(context)
-        firebaseDestination.analytics = mockedAnalytics
-    }
-
-    @Test
-    fun `settings are updated correctly`() {
-        // An example settings blob
-        val settingsBlob: Settings = Json.decodeFromString(
-            """
-            {
-              "integrations": {
-                "Firebase": {
-                }
-              }
-            }
-        """.trimIndent()
-        )
-        firebaseDestination.update(settingsBlob, Plugin.UpdateType.Initial)
-
-        assertNotNull(firebaseDestination.firebaseAnalytics)
-    }
-
-    @Test
-    fun `identify is handled correctly`() {
-        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-        val sampleEvent = IdentifyEvent(
-            userId = "abc-123",
-            traits = buildJsonObject {
-                put("email", "123@abc.com")
-                put("first.name", "123")
-            }
-        ).apply {
-            messageId = "qwerty-1234"
-            anonymousId = "anonId"
-            integrations = emptyJsonObject
-            context = emptyJsonObject
-            timestamp = "2021-07-13T00:59:09"
-        }
-        val identifyEvent = firebaseDestination.identify(sampleEvent)
-
-        assertNotNull(identifyEvent)
-
-        verify { mockedFirebase.setUserId("abc-123") }
-        verify { mockedFirebase.setUserProperty("email", "123@abc.com") }
-        verify { mockedFirebase.setUserProperty("first_name", "123") }
-    }
-
-    @Test
-    fun `onActivityResumed logs activity name`() {
-        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-        val mockManager = mockk<PackageManager>().apply {
-            every { getActivityInfo(any(), any()) } returns mockk<ActivityInfo>().apply {
-                every { loadLabel(any()) } returns "MockActivity"
-            }
-        }
-        val mockActivity = spyk(MockActivity())
-        every { mockActivity.packageManager } returns mockManager
-
-        firebaseDestination.onActivityResumed(mockActivity)
-
-        val bundleActual = slot<Bundle>()
-        verify { mockedFirebase.logEvent("screen_view", capture(bundleActual)) }
-        with(bundleActual.captured) {
-            assertEquals(1, this.size())
-            assertEquals("MockActivity", get("screen_name"))
-        }
-    }
-
-    @Test
-    fun `screen is fired when activity is available`() {
-        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-        val mockActivity = MockActivity()
-
-        val sampleEvent = ScreenEvent(
-            name = "LoginFragment",
-            properties = buildJsonObject {
-                put("startup", false)
-                put("parent", "MainActivity")
-            },
-            category = "signup_flow"
-        ).apply {
-            messageId = "qwerty-1234"
-            anonymousId = "anonId"
-            integrations = emptyJsonObject
-            context = emptyJsonObject
-            timestamp = "2021-07-13T00:59:09"
-        }
-
-        firebaseDestination.onActivityStarted(mockActivity)
-        val screenEvent = firebaseDestination.screen(sampleEvent)
-
-        /* assertions about new event */
-        assertNotNull(screenEvent)
-
-        val bundleActual = slot<Bundle>()
-
-        verify { mockedFirebase.logEvent("screen_view", capture(bundleActual)) }
-
-        with(bundleActual.captured) {
-            assertEquals(2, this.size())
-            assertEquals("LoginFragment", get("screen_name"))
-            assertEquals("MockActivity", get("screen_class"))
-        }
-
-    }
-
-    @Test
-    fun `screen is not fired when activity is unavailable`() {
-        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-        val sampleEvent = ScreenEvent(
-            name = "LoginFragment",
-            properties = buildJsonObject {
-                put("startup", false)
-                put("parent", "MainActivity")
-            },
-            category = "signup_flow"
-        ).apply {
-            messageId = "qwerty-1234"
-            anonymousId = "anonId"
-            integrations = emptyJsonObject
-            context = emptyJsonObject
-            timestamp = "2021-07-13T00:59:09"
-        }
-
-        val screenEvent = firebaseDestination.screen(sampleEvent)
-
-        /* assertions about new event */
-        assertNotNull(screenEvent)
-        with(screenEvent!! as ScreenEvent) {
-            assertEquals("LoginFragment", name)
-        }
-
-    }
-
-    @Test
-    fun `track changes event name based on mapper`() {
-        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-        val sampleEvent = TrackEvent(
-            event = "Product Clicked",
-            properties = emptyJsonObject
-        ).apply {
-            messageId = "qwerty-1234"
-            anonymousId = "anonId"
-            integrations = emptyJsonObject
-            context = emptyJsonObject
-            timestamp = "2021-07-13T00:59:09"
-        }
-        firebaseDestination.track(sampleEvent)
-
-        verify { mockedFirebase.logEvent("select_content", null) }
-    }
-
-    @Test
-    fun `track changes event name based on makeKey`() {
-        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-        val sampleEvent = TrackEvent(
-            event = "Button Clicked",
-            properties = emptyJsonObject
-        ).apply {
-            messageId = "qwerty-1234"
-            anonymousId = "anonId"
-            integrations = emptyJsonObject
-            context = emptyJsonObject
-            timestamp = "2021-07-13T00:59:09"
-        }
-        firebaseDestination.track(sampleEvent)
-        verify { mockedFirebase.logEvent("Button_Clicked", null) }
-    }
-
-    @Test
-    fun `track with properties`() {
-        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-        val sampleEvent = TrackEvent(
-            event = "Product Clicked",
-            properties = buildJsonObject {
-                put("category", "household")
-                put("query", "house items")
-                put("currency", "USD")
-                put("revenue", 160)
-                put("products", buildJsonArray {
-                    add(buildJsonObject {
-                        put("product_id", 1)
-                        put("price", 40)
-                        put("quantity", 2)
-                    })
-                    add(buildJsonObject {
-                        put("product_id", 2)
-                        put("price", 80)
-                        put("quantity", 1)
-                    })
-                })
-            }
-        ).apply {
-            messageId = "qwerty-1234"
-            anonymousId = "anonId"
-            integrations = emptyJsonObject
-            context = emptyJsonObject
-            timestamp = "2021-07-13T00:59:09"
-        }
-        firebaseDestination.track(sampleEvent)
-
-        val bundleActual = slot<Bundle>()
-        verify { mockedFirebase.logEvent("select_content", capture(bundleActual)) }
-
-        with(bundleActual.captured) {
-            val bundle = bundleOf(
-                "item_category" to "household",
-                "search_term" to "house items",
-                "currency" to "USD",
-                "value" to 160
-            ).apply {
-                putParcelableArrayList(
-                    "products", arrayListOf(
-                        bundleOf(
-                            "item_id" to 1,
-                            "price" to 40,
-                            "quantity" to 2
-                        ),
-                        bundleOf(
-                            "item_id" to 2,
-                            "price" to 80,
-                            "quantity" to 1
-                        )
-                    )
-                )
-            }
-            assertEquals(bundle.size(), size())
-
-            assertEquals("household", getString("item_category"))
-            assertEquals("house items", getString("search_term"))
-            assertEquals("USD", getString("currency"))
-            assertEquals(160, getInt("value"))
-            val products = getParcelableArrayList<Bundle>("item_list")
-            with(products!!) {
-                assertEquals(2, size)
-                with(get(0)!!) {
-                    assertEquals(1, getInt("item_id"))
-                    assertEquals(40, getInt("price"))
-                    assertEquals(2, getInt("quantity"))
-                }
-                with(get(1)!!) {
-                    assertEquals(2, getInt("item_id"))
-                    assertEquals(80, getInt("price"))
-                    assertEquals(1, getInt("quantity"))
-                }
-            }
-        }
-    }
-
-}
-
-class MockActivity : Activity()
+//@RunWith(RobolectricTestRunner::class)
+//@Config(sdk = [Build.VERSION_CODES.O_MR1])
+//class FirebaseDestinationTests {
+//
+//    @MockK
+//    lateinit var context: Context
+//
+//    @MockK(relaxUnitFun = true)
+//    lateinit var mockedAnalytics: Analytics
+//
+//    @MockK(relaxUnitFun = true)
+//    lateinit var mockedFirebase: FirebaseAnalytics
+//
+//    private val firebaseDestination: FirebaseDestination
+//
+//    init {
+//        MockKAnnotations.init(this)
+//        mockkStatic(FirebaseAnalytics::class)
+//        every { FirebaseAnalytics.getInstance(context) } returns mockedFirebase
+//
+//        // Need to mock log since its used in the destination
+////        mockkStatic("com.segment.analytics.kotlin.core.platform.plugins.LoggerKt")
+//
+//
+//        firebaseDestination = FirebaseDestination(context)
+//        firebaseDestination.analytics = mockedAnalytics
+//    }
+//
+//    @Test
+//    fun `settings are updated correctly`() {
+//        // An example settings blob
+//        val settingsBlob: Settings = Json.decodeFromString(
+//            """
+//            {
+//              "integrations": {
+//                "Firebase": {
+//                }
+//              }
+//            }
+//        """.trimIndent()
+//        )
+//        firebaseDestination.update(settingsBlob, Plugin.UpdateType.Initial)
+//
+//        assertNotNull(firebaseDestination.firebaseAnalytics)
+//    }
+//
+//    @Test
+//    fun `identify is handled correctly`() {
+//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+//        val sampleEvent = IdentifyEvent(
+//            userId = "abc-123",
+//            traits = buildJsonObject {
+//                put("email", "123@abc.com")
+//                put("first.name", "123")
+//            }
+//        ).apply {
+//            messageId = "qwerty-1234"
+//            anonymousId = "anonId"
+//            integrations = emptyJsonObject
+//            context = emptyJsonObject
+//            timestamp = "2021-07-13T00:59:09"
+//        }
+//        val identifyEvent = firebaseDestination.identify(sampleEvent)
+//
+//        assertNotNull(identifyEvent)
+//
+//        verify { mockedFirebase.setUserId("abc-123") }
+//        verify { mockedFirebase.setUserProperty("email", "123@abc.com") }
+//        verify { mockedFirebase.setUserProperty("first_name", "123") }
+//    }
+//
+//    @Test
+//    fun `onActivityResumed logs activity name`() {
+//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+//        val mockManager = mockk<PackageManager>().apply {
+//            every { getActivityInfo(any(), any()) } returns mockk<ActivityInfo>().apply {
+//                every { loadLabel(any()) } returns "MockActivity"
+//            }
+//        }
+//        val mockActivity = spyk(MockActivity())
+//        every { mockActivity.packageManager } returns mockManager
+//
+//        firebaseDestination.onActivityResumed(mockActivity)
+//
+//        val bundleActual = slot<Bundle>()
+//        verify { mockedFirebase.logEvent("screen_view", capture(bundleActual)) }
+//        with(bundleActual.captured) {
+//            assertEquals(1, this.size())
+//            assertEquals("MockActivity", get("screen_name"))
+//        }
+//    }
+//
+//    @Test
+//    fun `screen is fired when activity is available`() {
+//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+//        val mockActivity = MockActivity()
+//
+//        val sampleEvent = ScreenEvent(
+//            name = "LoginFragment",
+//            properties = buildJsonObject {
+//                put("startup", false)
+//                put("parent", "MainActivity")
+//            },
+//            category = "signup_flow"
+//        ).apply {
+//            messageId = "qwerty-1234"
+//            anonymousId = "anonId"
+//            integrations = emptyJsonObject
+//            context = emptyJsonObject
+//            timestamp = "2021-07-13T00:59:09"
+//        }
+//
+//        firebaseDestination.onActivityStarted(mockActivity)
+//        val screenEvent = firebaseDestination.screen(sampleEvent)
+//
+//        /* assertions about new event */
+//        assertNotNull(screenEvent)
+//
+//        val bundleActual = slot<Bundle>()
+//
+//        verify { mockedFirebase.logEvent("screen_view", capture(bundleActual)) }
+//
+//        with(bundleActual.captured) {
+//            assertEquals(2, this.size())
+//            assertEquals("LoginFragment", get("screen_name"))
+//            assertEquals("MockActivity", get("screen_class"))
+//        }
+//
+//    }
+//
+//    @Test
+//    fun `screen is not fired when activity is unavailable`() {
+//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+//        val sampleEvent = ScreenEvent(
+//            name = "LoginFragment",
+//            properties = buildJsonObject {
+//                put("startup", false)
+//                put("parent", "MainActivity")
+//            },
+//            category = "signup_flow"
+//        ).apply {
+//            messageId = "qwerty-1234"
+//            anonymousId = "anonId"
+//            integrations = emptyJsonObject
+//            context = emptyJsonObject
+//            timestamp = "2021-07-13T00:59:09"
+//        }
+//
+//        val screenEvent = firebaseDestination.screen(sampleEvent)
+//
+//        /* assertions about new event */
+//        assertNotNull(screenEvent)
+//        with(screenEvent!! as ScreenEvent) {
+//            assertEquals("LoginFragment", name)
+//        }
+//
+//    }
+//
+//    @Test
+//    fun `track changes event name based on mapper`() {
+//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+//        val sampleEvent = TrackEvent(
+//            event = "Product Clicked",
+//            properties = emptyJsonObject
+//        ).apply {
+//            messageId = "qwerty-1234"
+//            anonymousId = "anonId"
+//            integrations = emptyJsonObject
+//            context = emptyJsonObject
+//            timestamp = "2021-07-13T00:59:09"
+//        }
+//        firebaseDestination.track(sampleEvent)
+//
+//        verify { mockedFirebase.logEvent("select_content", null) }
+//    }
+//
+//    @Test
+//    fun `track changes event name based on makeKey`() {
+//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+//        val sampleEvent = TrackEvent(
+//            event = "Button Clicked",
+//            properties = emptyJsonObject
+//        ).apply {
+//            messageId = "qwerty-1234"
+//            anonymousId = "anonId"
+//            integrations = emptyJsonObject
+//            context = emptyJsonObject
+//            timestamp = "2021-07-13T00:59:09"
+//        }
+//        firebaseDestination.track(sampleEvent)
+//        verify { mockedFirebase.logEvent("Button_Clicked", null) }
+//    }
+//
+//    @Test
+//    fun `track with properties`() {
+//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+//        val sampleEvent = TrackEvent(
+//            event = "Product Clicked",
+//            properties = buildJsonObject {
+//                put("category", "household")
+//                put("query", "house items")
+//                put("currency", "USD")
+//                put("revenue", 160)
+//                put("products", buildJsonArray {
+//                    add(buildJsonObject {
+//                        put("product_id", 1)
+//                        put("price", 40)
+//                        put("quantity", 2)
+//                    })
+//                    add(buildJsonObject {
+//                        put("product_id", 2)
+//                        put("price", 80)
+//                        put("quantity", 1)
+//                    })
+//                })
+//            }
+//        ).apply {
+//            messageId = "qwerty-1234"
+//            anonymousId = "anonId"
+//            integrations = emptyJsonObject
+//            context = emptyJsonObject
+//            timestamp = "2021-07-13T00:59:09"
+//        }
+//        firebaseDestination.track(sampleEvent)
+//
+//        val bundleActual = slot<Bundle>()
+//        verify { mockedFirebase.logEvent("select_content", capture(bundleActual)) }
+//
+//        with(bundleActual.captured) {
+//            val bundle = bundleOf(
+//                "item_category" to "household",
+//                "search_term" to "house items",
+//                "currency" to "USD",
+//                "value" to 160
+//            ).apply {
+//                putParcelableArrayList(
+//                    "products", arrayListOf(
+//                        bundleOf(
+//                            "item_id" to 1,
+//                            "price" to 40,
+//                            "quantity" to 2
+//                        ),
+//                        bundleOf(
+//                            "item_id" to 2,
+//                            "price" to 80,
+//                            "quantity" to 1
+//                        )
+//                    )
+//                )
+//            }
+//            assertEquals(bundle.size(), size())
+//
+//            assertEquals("household", getString("item_category"))
+//            assertEquals("house items", getString("search_term"))
+//            assertEquals("USD", getString("currency"))
+//            assertEquals(160, getInt("value"))
+//            val products = getParcelableArrayList<Bundle>("item_list")
+//            with(products!!) {
+//                assertEquals(2, size)
+//                with(get(0)!!) {
+//                    assertEquals(1, getInt("item_id"))
+//                    assertEquals(40, getInt("price"))
+//                    assertEquals(2, getInt("quantity"))
+//                }
+//                with(get(1)!!) {
+//                    assertEquals(2, getInt("item_id"))
+//                    assertEquals(80, getInt("price"))
+//                    assertEquals(1, getInt("quantity"))
+//                }
+//            }
+//        }
+//    }
+//
+//}
+//
+//class MockActivity : Activity()

--- a/samples/kotlin-android-app-destinations/src/test/java/com/segment/analytics/destinations/plugins/FirebaseDestinationTest.kt
+++ b/samples/kotlin-android-app-destinations/src/test/java/com/segment/analytics/destinations/plugins/FirebaseDestinationTest.kt
@@ -1,278 +1,313 @@
 package com.segment.analytics.destinations.plugins
 
-//@RunWith(RobolectricTestRunner::class)
-//@Config(sdk = [Build.VERSION_CODES.O_MR1])
-//class FirebaseDestinationTests {
-//
-//    @MockK
-//    lateinit var context: Context
-//
-//    @MockK(relaxUnitFun = true)
-//    lateinit var mockedAnalytics: Analytics
-//
-//    @MockK(relaxUnitFun = true)
-//    lateinit var mockedFirebase: FirebaseAnalytics
-//
-//    private val firebaseDestination: FirebaseDestination
-//
-//    init {
-//        MockKAnnotations.init(this)
-//        mockkStatic(FirebaseAnalytics::class)
-//        every { FirebaseAnalytics.getInstance(context) } returns mockedFirebase
-//
-//        // Need to mock log since its used in the destination
-////        mockkStatic("com.segment.analytics.kotlin.core.platform.plugins.LoggerKt")
-//
-//
-//        firebaseDestination = FirebaseDestination(context)
-//        firebaseDestination.analytics = mockedAnalytics
-//    }
-//
-//    @Test
-//    fun `settings are updated correctly`() {
-//        // An example settings blob
-//        val settingsBlob: Settings = Json.decodeFromString(
-//            """
-//            {
-//              "integrations": {
-//                "Firebase": {
-//                }
-//              }
-//            }
-//        """.trimIndent()
-//        )
-//        firebaseDestination.update(settingsBlob, Plugin.UpdateType.Initial)
-//
-//        assertNotNull(firebaseDestination.firebaseAnalytics)
-//    }
-//
-//    @Test
-//    fun `identify is handled correctly`() {
-//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-//        val sampleEvent = IdentifyEvent(
-//            userId = "abc-123",
-//            traits = buildJsonObject {
-//                put("email", "123@abc.com")
-//                put("first.name", "123")
-//            }
-//        ).apply {
-//            messageId = "qwerty-1234"
-//            anonymousId = "anonId"
-//            integrations = emptyJsonObject
-//            context = emptyJsonObject
-//            timestamp = "2021-07-13T00:59:09"
-//        }
-//        val identifyEvent = firebaseDestination.identify(sampleEvent)
-//
-//        assertNotNull(identifyEvent)
-//
-//        verify { mockedFirebase.setUserId("abc-123") }
-//        verify { mockedFirebase.setUserProperty("email", "123@abc.com") }
-//        verify { mockedFirebase.setUserProperty("first_name", "123") }
-//    }
-//
-//    @Test
-//    fun `onActivityResumed logs activity name`() {
-//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-//        val mockManager = mockk<PackageManager>().apply {
-//            every { getActivityInfo(any(), any()) } returns mockk<ActivityInfo>().apply {
-//                every { loadLabel(any()) } returns "MockActivity"
-//            }
-//        }
-//        val mockActivity = spyk(MockActivity())
-//        every { mockActivity.packageManager } returns mockManager
-//
-//        firebaseDestination.onActivityResumed(mockActivity)
-//
-//        val bundleActual = slot<Bundle>()
-//        verify { mockedFirebase.logEvent("screen_view", capture(bundleActual)) }
-//        with(bundleActual.captured) {
-//            assertEquals(1, this.size())
-//            assertEquals("MockActivity", get("screen_name"))
-//        }
-//    }
-//
-//    @Test
-//    fun `screen is fired when activity is available`() {
-//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-//        val mockActivity = MockActivity()
-//
-//        val sampleEvent = ScreenEvent(
-//            name = "LoginFragment",
-//            properties = buildJsonObject {
-//                put("startup", false)
-//                put("parent", "MainActivity")
-//            },
-//            category = "signup_flow"
-//        ).apply {
-//            messageId = "qwerty-1234"
-//            anonymousId = "anonId"
-//            integrations = emptyJsonObject
-//            context = emptyJsonObject
-//            timestamp = "2021-07-13T00:59:09"
-//        }
-//
-//        firebaseDestination.onActivityStarted(mockActivity)
-//        val screenEvent = firebaseDestination.screen(sampleEvent)
-//
-//        /* assertions about new event */
-//        assertNotNull(screenEvent)
-//
-//        val bundleActual = slot<Bundle>()
-//
-//        verify { mockedFirebase.logEvent("screen_view", capture(bundleActual)) }
-//
-//        with(bundleActual.captured) {
-//            assertEquals(2, this.size())
-//            assertEquals("LoginFragment", get("screen_name"))
-//            assertEquals("MockActivity", get("screen_class"))
-//        }
-//
-//    }
-//
-//    @Test
-//    fun `screen is not fired when activity is unavailable`() {
-//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-//        val sampleEvent = ScreenEvent(
-//            name = "LoginFragment",
-//            properties = buildJsonObject {
-//                put("startup", false)
-//                put("parent", "MainActivity")
-//            },
-//            category = "signup_flow"
-//        ).apply {
-//            messageId = "qwerty-1234"
-//            anonymousId = "anonId"
-//            integrations = emptyJsonObject
-//            context = emptyJsonObject
-//            timestamp = "2021-07-13T00:59:09"
-//        }
-//
-//        val screenEvent = firebaseDestination.screen(sampleEvent)
-//
-//        /* assertions about new event */
-//        assertNotNull(screenEvent)
-//        with(screenEvent!! as ScreenEvent) {
-//            assertEquals("LoginFragment", name)
-//        }
-//
-//    }
-//
-//    @Test
-//    fun `track changes event name based on mapper`() {
-//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-//        val sampleEvent = TrackEvent(
-//            event = "Product Clicked",
-//            properties = emptyJsonObject
-//        ).apply {
-//            messageId = "qwerty-1234"
-//            anonymousId = "anonId"
-//            integrations = emptyJsonObject
-//            context = emptyJsonObject
-//            timestamp = "2021-07-13T00:59:09"
-//        }
-//        firebaseDestination.track(sampleEvent)
-//
-//        verify { mockedFirebase.logEvent("select_content", null) }
-//    }
-//
-//    @Test
-//    fun `track changes event name based on makeKey`() {
-//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-//        val sampleEvent = TrackEvent(
-//            event = "Button Clicked",
-//            properties = emptyJsonObject
-//        ).apply {
-//            messageId = "qwerty-1234"
-//            anonymousId = "anonId"
-//            integrations = emptyJsonObject
-//            context = emptyJsonObject
-//            timestamp = "2021-07-13T00:59:09"
-//        }
-//        firebaseDestination.track(sampleEvent)
-//        verify { mockedFirebase.logEvent("Button_Clicked", null) }
-//    }
-//
-//    @Test
-//    fun `track with properties`() {
-//        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-//        val sampleEvent = TrackEvent(
-//            event = "Product Clicked",
-//            properties = buildJsonObject {
-//                put("category", "household")
-//                put("query", "house items")
-//                put("currency", "USD")
-//                put("revenue", 160)
-//                put("products", buildJsonArray {
-//                    add(buildJsonObject {
-//                        put("product_id", 1)
-//                        put("price", 40)
-//                        put("quantity", 2)
-//                    })
-//                    add(buildJsonObject {
-//                        put("product_id", 2)
-//                        put("price", 80)
-//                        put("quantity", 1)
-//                    })
-//                })
-//            }
-//        ).apply {
-//            messageId = "qwerty-1234"
-//            anonymousId = "anonId"
-//            integrations = emptyJsonObject
-//            context = emptyJsonObject
-//            timestamp = "2021-07-13T00:59:09"
-//        }
-//        firebaseDestination.track(sampleEvent)
-//
-//        val bundleActual = slot<Bundle>()
-//        verify { mockedFirebase.logEvent("select_content", capture(bundleActual)) }
-//
-//        with(bundleActual.captured) {
-//            val bundle = bundleOf(
-//                "item_category" to "household",
-//                "search_term" to "house items",
-//                "currency" to "USD",
-//                "value" to 160
-//            ).apply {
-//                putParcelableArrayList(
-//                    "products", arrayListOf(
-//                        bundleOf(
-//                            "item_id" to 1,
-//                            "price" to 40,
-//                            "quantity" to 2
-//                        ),
-//                        bundleOf(
-//                            "item_id" to 2,
-//                            "price" to 80,
-//                            "quantity" to 1
-//                        )
-//                    )
-//                )
-//            }
-//            assertEquals(bundle.size(), size())
-//
-//            assertEquals("household", getString("item_category"))
-//            assertEquals("house items", getString("search_term"))
-//            assertEquals("USD", getString("currency"))
-//            assertEquals(160, getInt("value"))
-//            val products = getParcelableArrayList<Bundle>("item_list")
-//            with(products!!) {
-//                assertEquals(2, size)
-//                with(get(0)!!) {
-//                    assertEquals(1, getInt("item_id"))
-//                    assertEquals(40, getInt("price"))
-//                    assertEquals(2, getInt("quantity"))
-//                }
-//                with(get(1)!!) {
-//                    assertEquals(2, getInt("item_id"))
-//                    assertEquals(80, getInt("price"))
-//                    assertEquals(1, getInt("quantity"))
-//                }
-//            }
-//        }
-//    }
-//
-//}
-//
-//class MockActivity : Activity()
+import android.app.Activity
+import android.content.Context
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.IdentifyEvent
+import com.segment.analytics.kotlin.core.ScreenEvent
+import com.segment.analytics.kotlin.core.Settings
+import com.segment.analytics.kotlin.core.TrackEvent
+import com.segment.analytics.kotlin.core.emptyJsonObject
+import com.segment.analytics.kotlin.core.platform.Plugin
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+class FirebaseDestinationTests {
+
+    @MockK
+    lateinit var context: Context
+
+    @MockK(relaxUnitFun = true)
+    lateinit var mockedAnalytics: Analytics
+
+    @MockK(relaxUnitFun = true)
+    lateinit var mockedFirebase: FirebaseAnalytics
+
+    private val firebaseDestination: FirebaseDestination
+
+    init {
+        MockKAnnotations.init(this)
+        mockkStatic(FirebaseAnalytics::class)
+        every { FirebaseAnalytics.getInstance(context) } returns mockedFirebase
+
+        // Need to mock log since its used in the destination
+//        mockkStatic("com.segment.analytics.kotlin.core.platform.plugins.LoggerKt")
+
+
+        firebaseDestination = FirebaseDestination(context)
+        firebaseDestination.analytics = mockedAnalytics
+    }
+
+    @Test
+    fun `settings are updated correctly`() {
+        // An example settings blob
+        val settingsBlob: Settings = Json.decodeFromString(
+            """
+            {
+              "integrations": {
+                "Firebase": {
+                }
+              }
+            }
+        """.trimIndent()
+        )
+        firebaseDestination.update(settingsBlob, Plugin.UpdateType.Initial)
+
+        assertNotNull(firebaseDestination.firebaseAnalytics)
+    }
+
+    @Test
+    fun `identify is handled correctly`() {
+        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+        val sampleEvent = IdentifyEvent(
+            userId = "abc-123",
+            traits = buildJsonObject {
+                put("email", "123@abc.com")
+                put("first.name", "123")
+            }
+        ).apply {
+            messageId = "qwerty-1234"
+            anonymousId = "anonId"
+            integrations = emptyJsonObject
+            context = emptyJsonObject
+            timestamp = "2021-07-13T00:59:09"
+        }
+        val identifyEvent = firebaseDestination.identify(sampleEvent)
+
+        assertNotNull(identifyEvent)
+
+        verify { mockedFirebase.setUserId("abc-123") }
+        verify { mockedFirebase.setUserProperty("email", "123@abc.com") }
+        verify { mockedFirebase.setUserProperty("first_name", "123") }
+    }
+
+    @Test
+    fun `onActivityResumed logs activity name`() {
+        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+        val mockManager = mockk<PackageManager>().apply {
+            every { getActivityInfo(any(), any()) } returns mockk<ActivityInfo>().apply {
+                every { loadLabel(any()) } returns "MockActivity"
+            }
+        }
+        val mockActivity = spyk(MockActivity())
+        every { mockActivity.packageManager } returns mockManager
+
+        firebaseDestination.onActivityResumed(mockActivity)
+
+        val bundleActual = slot<Bundle>()
+        verify { mockedFirebase.logEvent("screen_view", capture(bundleActual)) }
+        with(bundleActual.captured) {
+            assertEquals(1, this.size())
+            assertEquals("MockActivity", get("screen_name"))
+        }
+    }
+
+    @Test
+    fun `screen is fired when activity is available`() {
+        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+        val mockActivity = MockActivity()
+
+        val sampleEvent = ScreenEvent(
+            name = "LoginFragment",
+            properties = buildJsonObject {
+                put("startup", false)
+                put("parent", "MainActivity")
+            },
+            category = "signup_flow"
+        ).apply {
+            messageId = "qwerty-1234"
+            anonymousId = "anonId"
+            integrations = emptyJsonObject
+            context = emptyJsonObject
+            timestamp = "2021-07-13T00:59:09"
+        }
+
+        firebaseDestination.onActivityStarted(mockActivity)
+        val screenEvent = firebaseDestination.screen(sampleEvent)
+
+        /* assertions about new event */
+        assertNotNull(screenEvent)
+
+        val bundleActual = slot<Bundle>()
+
+        verify { mockedFirebase.logEvent("screen_view", capture(bundleActual)) }
+
+        with(bundleActual.captured) {
+            assertEquals(2, this.size())
+            assertEquals("LoginFragment", get("screen_name"))
+            assertEquals("MockActivity", get("screen_class"))
+        }
+
+    }
+
+    @Test
+    fun `screen is not fired when activity is unavailable`() {
+        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+        val sampleEvent = ScreenEvent(
+            name = "LoginFragment",
+            properties = buildJsonObject {
+                put("startup", false)
+                put("parent", "MainActivity")
+            },
+            category = "signup_flow"
+        ).apply {
+            messageId = "qwerty-1234"
+            anonymousId = "anonId"
+            integrations = emptyJsonObject
+            context = emptyJsonObject
+            timestamp = "2021-07-13T00:59:09"
+        }
+
+        val screenEvent = firebaseDestination.screen(sampleEvent)
+
+        /* assertions about new event */
+        assertNotNull(screenEvent)
+        with(screenEvent!! as ScreenEvent) {
+            assertEquals("LoginFragment", name)
+        }
+
+    }
+
+    @Test
+    fun `track changes event name based on mapper`() {
+        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+        val sampleEvent = TrackEvent(
+            event = "Product Clicked",
+            properties = emptyJsonObject
+        ).apply {
+            messageId = "qwerty-1234"
+            anonymousId = "anonId"
+            integrations = emptyJsonObject
+            context = emptyJsonObject
+            timestamp = "2021-07-13T00:59:09"
+        }
+        firebaseDestination.track(sampleEvent)
+
+        verify { mockedFirebase.logEvent("select_content", null) }
+    }
+
+    @Test
+    fun `track changes event name based on makeKey`() {
+        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+        val sampleEvent = TrackEvent(
+            event = "Button Clicked",
+            properties = emptyJsonObject
+        ).apply {
+            messageId = "qwerty-1234"
+            anonymousId = "anonId"
+            integrations = emptyJsonObject
+            context = emptyJsonObject
+            timestamp = "2021-07-13T00:59:09"
+        }
+        firebaseDestination.track(sampleEvent)
+        verify { mockedFirebase.logEvent("Button_Clicked", null) }
+    }
+
+    @Test
+    fun `track with properties`() {
+        firebaseDestination.firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+        val sampleEvent = TrackEvent(
+            event = "Product Clicked",
+            properties = buildJsonObject {
+                put("category", "household")
+                put("query", "house items")
+                put("currency", "USD")
+                put("revenue", 160)
+                put("products", buildJsonArray {
+                    add(buildJsonObject {
+                        put("product_id", 1)
+                        put("price", 40)
+                        put("quantity", 2)
+                    })
+                    add(buildJsonObject {
+                        put("product_id", 2)
+                        put("price", 80)
+                        put("quantity", 1)
+                    })
+                })
+            }
+        ).apply {
+            messageId = "qwerty-1234"
+            anonymousId = "anonId"
+            integrations = emptyJsonObject
+            context = emptyJsonObject
+            timestamp = "2021-07-13T00:59:09"
+        }
+        firebaseDestination.track(sampleEvent)
+
+        val bundleActual = slot<Bundle>()
+        verify { mockedFirebase.logEvent("select_content", capture(bundleActual)) }
+
+        with(bundleActual.captured) {
+            val bundle = bundleOf(
+                "item_category" to "household",
+                "search_term" to "house items",
+                "currency" to "USD",
+                "value" to 160
+            ).apply {
+                putParcelableArrayList(
+                    "products", arrayListOf(
+                        bundleOf(
+                            "item_id" to 1,
+                            "price" to 40,
+                            "quantity" to 2
+                        ),
+                        bundleOf(
+                            "item_id" to 2,
+                            "price" to 80,
+                            "quantity" to 1
+                        )
+                    )
+                )
+            }
+            assertEquals(bundle.size(), size())
+
+            assertEquals("household", getString("item_category"))
+            assertEquals("house items", getString("search_term"))
+            assertEquals("USD", getString("currency"))
+            assertEquals(160, getInt("value"))
+            val products = getParcelableArrayList<Bundle>("item_list")
+            with(products!!) {
+                assertEquals(2, size)
+                with(get(0)!!) {
+                    assertEquals(1, getInt("item_id"))
+                    assertEquals(40, getInt("price"))
+                    assertEquals(2, getInt("quantity"))
+                }
+                with(get(1)!!) {
+                    assertEquals(2, getInt("item_id"))
+                    assertEquals(80, getInt("price"))
+                    assertEquals(1, getInt("quantity"))
+                }
+            }
+        }
+    }
+
+}
+
+class MockActivity : Activity()


### PR DESCRIPTION
- Correct how events select which device-mode destinations to run against
- Move logic for device-mode destinations data to Segment.io destination plugin
- Add a new API to allow manually enabling destinations (useful for destination plugins with no Segment tie-ins)
- Add a new API to allow copying payloads with ease