### PR TITLE
Wenxi/convenience methods and misses for plugin authors

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Events.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Events.kt
@@ -79,6 +79,10 @@ sealed class BaseEvent {
     // the userId tied to the event
     abstract var userId: String
 
+    companion object {
+        internal const val ALL_INTEGRATIONS_KEY = "All"
+    }
+
     internal fun applyBaseData() {
         this.timestamp = Instant.now().toString()
         this.context = emptyJsonObject

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventManipulationFunctions.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventManipulationFunctions.kt
@@ -10,12 +10,13 @@ import kotlinx.serialization.serializer
 
 // Mark integration as enabled, for this event
 fun BaseEvent.enableIntegration(integrationName: String): BaseEvent {
-    // if it's a dictionary already, it's considered enabled, so don't
-    // overwrite whatever they may have put there.  If that's not the case
-    // just set it to true since that's the only other value it could have
-    // to be considered `enabled`.
-    val currentValue = integrations.getBoolean(integrationName)
-    currentValue?.let { enabled ->
+    // if not exist yet, enable it
+    if (!integrations.containsKey(integrationName)) {
+        return putIntegrations(integrationName, true)
+    }
+
+    // if it's a boolean value
+    integrations.getBoolean(integrationName)?.let { enabled ->
         // if it's not enabled, enable it
         // otherwise, do nothing
         if (!enabled) {
@@ -23,6 +24,8 @@ fun BaseEvent.enableIntegration(integrationName: String): BaseEvent {
         }
     }
 
+    // otherwise it's a dictionary already, it's considered enabled, so don't
+    // overwrite whatever they may have put there.
     return this
 }
 
@@ -120,9 +123,12 @@ fun BaseEvent.disableCloudIntegrations(exceptKeys: List<String>? = null): BaseEv
 
         exceptKeys?.forEach { key ->
             if (integrations.containsKey(key)) {
-                integrations.getBoolean(key)?.let {
+                if(integrations.getBoolean(key) != null) {
                     put(key, true)
-                } ?: put(key, integrations.getString(key))
+                }
+                else {
+                    put(key, integrations[key]!!)
+                }
             }
         }
     }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventManipulationFunctions.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventManipulationFunctions.kt
@@ -10,7 +10,20 @@ import kotlinx.serialization.serializer
 
 // Mark integration as enabled, for this event
 fun BaseEvent.enableIntegration(integrationName: String): BaseEvent {
-    return putIntegrations(integrationName, true)
+    // if it's a dictionary already, it's considered enabled, so don't
+    // overwrite whatever they may have put there.  If that's not the case
+    // just set it to true since that's the only other value it could have
+    // to be considered `enabled`.
+    val currentValue = integrations.getBoolean(integrationName)
+    currentValue?.let { enabled ->
+        // if it's not enabled, enable it
+        // otherwise, do nothing
+        if (!enabled) {
+            return putIntegrations(integrationName, true)
+        }
+    }
+
+    return this
 }
 
 // Mark integration as disabled, for this event
@@ -97,5 +110,34 @@ inline fun <reified T : Any> BaseEvent.putInContextUnderKey(
 
 fun BaseEvent.removeFromContext(key: String): BaseEvent {
     context = JsonObject(context.filterNot { (k, _) -> k == key })
+    return this
+}
+
+
+fun BaseEvent.disableCloudIntegrations(exceptKeys: List<String>? = null): BaseEvent {
+    integrations = buildJsonObject {
+        put(BaseEvent.ALL_INTEGRATIONS_KEY, false)
+
+        exceptKeys?.forEach { key ->
+            if (integrations.containsKey(key)) {
+                integrations.getBoolean(key)?.let {
+                    put(key, true)
+                } ?: put(key, integrations.getString(key))
+            }
+        }
+    }
+
+    return this
+}
+
+fun BaseEvent.enableCloudIntegrations(exceptKeys: List<String>? = null): BaseEvent {
+    integrations = buildJsonObject {
+        put(BaseEvent.ALL_INTEGRATIONS_KEY, true)
+
+        exceptKeys?.forEach { key ->
+            put(key, false)
+        }
+    }
+
     return this
 }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/JSON.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/JSON.kt
@@ -181,3 +181,27 @@ fun JsonObject.transformKeys(transform: (String) -> String): JsonObject {
 fun JsonObject.transformValues(transform: (JsonElement) -> JsonElement): JsonObject {
     return JsonObject(this.mapValues { transform(it.value) })
 }
+
+// Utility function to update a JsonObject. The updated copy is returned. Original copy is not touched
+fun updateJsonObject(jsonObject: JsonObject, closure: (MutableMap<String, JsonElement>) -> Unit): JsonObject {
+    val content = jsonObject.toMutableMap()
+    closure(content)
+    return JsonObject(content)
+}
+
+operator fun MutableMap<String, JsonElement>.set(key:String, value: String?) {
+    if (value == null) {
+        remove(key)
+    }
+    else {
+        this[key] = JsonPrimitive(value)
+    }
+}
+
+operator fun MutableMap<String, JsonElement>.set(key:String, value: Number) {
+    this[key] = JsonPrimitive(value)
+}
+
+operator fun MutableMap<String, JsonElement>.set(key:String, value: Boolean) {
+    this[key] = JsonPrimitive(value)
+}

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/JSONTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/JSONTests.kt
@@ -732,36 +732,36 @@ class JSONTests {
             obj = updateJsonObject(obj) {
                 it["foo"] = "bar"
             }
-            assertEquals(obj.size, 1)
-            assertEquals(obj.getString("foo"), "bar")
+            assertEquals(1, obj.size)
+            assertEquals("bar", obj.getString("foo"))
 
             // test number
             obj = updateJsonObject(obj) {
                 it["foo"] = null
                 it["number"] = 1
             }
-            assertEquals(obj.size, 1)
-            assertEquals(obj.getInt("number"), 1)
+            assertEquals(1, obj.size)
+            assertEquals(1, obj.getInt("number"))
 
             obj = updateJsonObject(obj) {
                 it["number"] = 2.0
             }
-            assertEquals(obj.size, 1)
-            assertEquals(obj.getDouble("number"), 2.0)
+            assertEquals(1, obj.size)
+            assertEquals(2.0, obj.getDouble("number"))
 
             obj = updateJsonObject(obj) {
                 it["number"] = 4L
             }
-            assertEquals(obj.size, 1)
-            assertEquals(obj.getLong("number"), 4L)
+            assertEquals(1, obj.size)
+            assertEquals(4L, obj.getLong("number"))
 
             // test boolean
             obj = updateJsonObject(obj) {
                 it["number"] = null
                 it["boolean"] = true
             }
-            assertEquals(obj.size, 1)
-            assertEquals(obj.getBoolean("boolean"), true)
+            assertEquals(1, obj.size)
+            assertEquals(true, obj.getBoolean("boolean"))
         }
     }
 }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/JSONTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/JSONTests.kt
@@ -1,18 +1,6 @@
 package com.segment.analytics.kotlin.core
 
-import com.segment.analytics.kotlin.core.utilities.getBoolean
-import com.segment.analytics.kotlin.core.utilities.getDouble
-import com.segment.analytics.kotlin.core.utilities.getInt
-import com.segment.analytics.kotlin.core.utilities.getLong
-import com.segment.analytics.kotlin.core.utilities.getMapList
-import com.segment.analytics.kotlin.core.utilities.getString
-import com.segment.analytics.kotlin.core.utilities.getStringSet
-import com.segment.analytics.kotlin.core.utilities.mapTransform
-import com.segment.analytics.kotlin.core.utilities.putAll
-import com.segment.analytics.kotlin.core.utilities.putUndefinedIfNull
-import com.segment.analytics.kotlin.core.utilities.toContent
-import com.segment.analytics.kotlin.core.utilities.transformKeys
-import com.segment.analytics.kotlin.core.utilities.transformValues
+import com.segment.analytics.kotlin.core.utilities.*
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.boolean
@@ -731,6 +719,49 @@ class JSONTests {
                 putUndefinedIfNull("foo", null)
             }
             assertEquals("undefined", x.getString("foo"))
+        }
+    }
+
+    @Nested
+    inner class UpdateJsonObjectTests {
+        @Test
+        fun `updateJsonObject updates values`() {
+            var obj = emptyJsonObject
+
+            // test string
+            obj = updateJsonObject(obj) {
+                it["foo"] = "bar"
+            }
+            assertEquals(obj.size, 1)
+            assertEquals(obj.getString("foo"), "bar")
+
+            // test number
+            obj = updateJsonObject(obj) {
+                it["foo"] = null
+                it["number"] = 1
+            }
+            assertEquals(obj.size, 1)
+            assertEquals(obj.getInt("number"), 1)
+
+            obj = updateJsonObject(obj) {
+                it["number"] = 2.0
+            }
+            assertEquals(obj.size, 1)
+            assertEquals(obj.getDouble("number"), 2.0)
+
+            obj = updateJsonObject(obj) {
+                it["number"] = 4L
+            }
+            assertEquals(obj.size, 1)
+            assertEquals(obj.getLong("number"), 4L)
+
+            // test boolean
+            obj = updateJsonObject(obj) {
+                it["number"] = null
+                it["boolean"] = true
+            }
+            assertEquals(obj.size, 1)
+            assertEquals(obj.getBoolean("boolean"), true)
         }
     }
 }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/EventManipulationFunctionsTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/EventManipulationFunctionsTest.kt
@@ -1,0 +1,176 @@
+package com.segment.analytics.kotlin.core.utilities
+
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.TrackEvent
+import com.segment.analytics.kotlin.core.emptyJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class EventManipulationFunctionsTest {
+
+    @Test
+    fun `enableIntegration enables integration when not exist`() {
+        val trackEvent = TrackEvent(
+            event = "clicked",
+            properties = buildJsonObject { put("behaviour", "good") })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = emptyJsonObject
+                context = emptyJsonObject
+            }
+
+        trackEvent.enableIntegration("test")
+
+        assertEquals(true, trackEvent.integrations.getBoolean("test"))
+    }
+
+    @Test
+    fun `enableIntegration enables integration when disable`() {
+        val trackEvent = TrackEvent(
+            event = "clicked",
+            properties = buildJsonObject { put("behaviour", "good") })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = buildJsonObject { put("test", false) }
+                context = emptyJsonObject
+            }
+
+        trackEvent.enableIntegration("test")
+
+        assertEquals(true, trackEvent.integrations.getBoolean("test"))
+    }
+
+    @Test
+    fun `enableIntegration enables integration when non-boolean`() {
+        val jsonObject = buildJsonObject { put("key", "value") }
+        val trackEvent = TrackEvent(
+            event = "clicked",
+            properties = buildJsonObject { put("behaviour", "good") })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = buildJsonObject { put("test", jsonObject) }
+                context = emptyJsonObject
+            }
+
+        trackEvent.enableIntegration("test")
+
+        assertEquals(jsonObject, trackEvent.integrations["test"])
+    }
+
+    @Test
+    fun `disableCloudIntegrations with except list`() {
+        val jsonObject = buildJsonObject { put("key", "value") }
+        val trackEvent = TrackEvent(
+            event = "clicked",
+            properties = buildJsonObject { put("behaviour", "good") })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = buildJsonObject {
+                    put("discard1", true)
+                    put("discard2", false)
+                    put("discard3", "string")
+                    put("discard4", jsonObject)
+                    put("keep1", true)
+                    put("keep2", false)
+                    put("keep3", "string")
+                    put("keep4", jsonObject)
+                }
+                context = emptyJsonObject
+            }
+
+        trackEvent.disableCloudIntegrations(exceptKeys = listOf("keep1", "keep2", "keep3", "keep4"))
+
+        assertEquals(5, trackEvent.integrations.size)
+        assertEquals(false, trackEvent.integrations.getBoolean(BaseEvent.ALL_INTEGRATIONS_KEY))
+        assertEquals(true, trackEvent.integrations.getBoolean("keep1"))
+        assertEquals(true, trackEvent.integrations.getBoolean("keep2"))
+        assertEquals("string", trackEvent.integrations.getString("keep3"))
+        assertEquals(jsonObject, trackEvent.integrations["keep4"])
+    }
+
+    @Test
+    fun `disableCloudIntegrations with null`() {
+        val jsonObject = buildJsonObject { put("key", "value") }
+        val trackEvent = TrackEvent(
+            event = "clicked",
+            properties = buildJsonObject { put("behaviour", "good") })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = buildJsonObject {
+                    put("discard1", true)
+                    put("discard2", false)
+                    put("discard3", "string")
+                    put("discard4", jsonObject)
+                }
+                context = emptyJsonObject
+            }
+
+        trackEvent.disableCloudIntegrations()
+
+        assertEquals(1, trackEvent.integrations.size)
+        assertEquals(false, trackEvent.integrations.getBoolean(BaseEvent.ALL_INTEGRATIONS_KEY))
+    }
+
+    @Test
+    fun `enableCloudIntegrations with except list`() {
+        val jsonObject = buildJsonObject { put("key", "value") }
+        val trackEvent = TrackEvent(
+            event = "clicked",
+            properties = buildJsonObject { put("behaviour", "good") })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = buildJsonObject {
+                    put("discard1", true)
+                    put("discard2", false)
+                    put("discard3", "string")
+                    put("discard4", jsonObject)
+                    put("keep1", true)
+                    put("keep2", false)
+                    put("keep3", "string")
+                    put("keep4", jsonObject)
+                }
+                context = emptyJsonObject
+            }
+
+        trackEvent.enableCloudIntegrations(exceptKeys = listOf("keep1", "keep2", "keep3", "keep4"))
+
+        assertEquals(5, trackEvent.integrations.size)
+        assertEquals(true, trackEvent.integrations.getBoolean(BaseEvent.ALL_INTEGRATIONS_KEY))
+        assertEquals(false, trackEvent.integrations.getBoolean("keep1"))
+        assertEquals(false, trackEvent.integrations.getBoolean("keep2"))
+        assertEquals(false, trackEvent.integrations.getBoolean("keep3"))
+        assertEquals(false, trackEvent.integrations.getBoolean("keep4"))
+    }
+
+    @Test
+    fun `enableCloudIntegrations with null`() {
+        val jsonObject = buildJsonObject { put("key", "value") }
+        val trackEvent = TrackEvent(
+            event = "clicked",
+            properties = buildJsonObject { put("behaviour", "good") })
+            .apply {
+                messageId = "qwerty-1234"
+                anonymousId = "anonId"
+                integrations = buildJsonObject {
+                    put("discard1", true)
+                    put("discard2", false)
+                    put("discard3", "string")
+                    put("discard4", jsonObject)
+                }
+                context = emptyJsonObject
+            }
+
+        trackEvent.enableCloudIntegrations()
+
+        assertEquals(1, trackEvent.integrations.size)
+        assertEquals(true, trackEvent.integrations.getBoolean(BaseEvent.ALL_INTEGRATIONS_KEY))
+    }
+}

--- a/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/IntercomDestination.kt
+++ b/samples/kotlin-android-app-destinations/src/main/java/com/segment/analytics/destinations/plugins/IntercomDestination.kt
@@ -209,9 +209,14 @@ class IntercomDestination(
 
     private fun setCompany(company: JsonObject): Company {
         val builder = Company.Builder()
-        company.getString("id")?.let {
-            builder.withCompanyId(it)
-        } ?: return builder.build()
+
+        val id = company.getString("id")
+        if (id == null) {
+            return builder.build()
+        }
+        else {
+            builder.withCompanyId(id)
+        }
 
         company.getString(NAME)?.let { builder.withName(it) }
         company.getLong(CREATED_AT)?.let { builder.withCreatedAt(it) }


### PR DESCRIPTION
* added `enableIntegration`, `disableIntegration`, `disableCloudIntegrations`, `enableCloudIntegrations`
* added `updateJsonObject` to JSON wrapper for easier content manipulation
* added unit tests
* fixed a bug in intercom integration
* `manuallyEnableDestination` is already implemented in pr #59 