### PR TITLE
fix api host being overwritten by default value

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
@@ -18,7 +18,7 @@ import kotlinx.serialization.json.jsonPrimitive
 @Serializable
 data class SegmentSettings(
     var apiKey: String,
-    var apiHost: String = DEFAULT_API_HOST,
+    var apiHost: String? = null
 )
 
 /**
@@ -95,8 +95,8 @@ class SegmentDestination : DestinationPlugin(), VersionedPlugin {
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         super.update(settings, type)
         if (settings.hasIntegrationSettings(this)) {
-            settings.destinationSettings<SegmentSettings>(key)?.let {
-                pipeline.apiHost = it.apiHost
+            settings.destinationSettings<SegmentSettings>(key)?.apiHost?.let {
+                pipeline.apiHost = it
             }
         }
     }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
@@ -95,6 +95,7 @@ class SegmentDestination : DestinationPlugin(), VersionedPlugin {
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         super.update(settings, type)
         if (settings.hasIntegrationSettings(this)) {
+            // only populate the apiHost value if it exists
             settings.destinationSettings<SegmentSettings>(key)?.apiHost?.let {
                 pipeline.apiHost = it
             }


### PR DESCRIPTION
* fix api host being overwritten by default value
* now the apiHost value honors in the following order: remote apiHost > local modified apiHost > default apiHost