### PR TITLE
address event plugin disparity and track issue

### DIFF
--- a/android/src/test/java/com/segment/analytics/kotlin/android/utils/Plugins.kt
+++ b/android/src/test/java/com/segment/analytics/kotlin/android/utils/Plugins.kt
@@ -17,6 +17,7 @@ class TestRunPlugin(var closure: (BaseEvent?) -> Unit): EventPlugin {
     }
 
     override fun execute(event: BaseEvent): BaseEvent {
+        super.execute(event)
         updateState(true)
         return event
     }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
@@ -100,11 +100,11 @@ open class Analytics protected constructor(
                 storage.subscribeToStore()
             }
 
-            checkSettings()
-
             if (configuration.autoAddSegmentDestination) {
                 add(SegmentDestination())
             }
+
+            checkSettings()
         }
     }
 

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Mediator.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Mediator.kt
@@ -24,13 +24,13 @@ internal class Mediator(internal val plugins: MutableList<Plugin>) {
         var result: BaseEvent? = event
 
         plugins.forEach { plugin ->
-            if (result != null) {
+            result?.let {
                 when (plugin) {
                     is DestinationPlugin -> {
-                        plugin.execute(result!!)
+                        plugin.execute(it)
                     }
                     else -> {
-                        result = plugin.execute(result!!)
+                        result = plugin.execute(it)
                     }
                 }
             }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Mediator.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Mediator.kt
@@ -27,29 +27,10 @@ internal class Mediator(internal val plugins: MutableList<Plugin>) {
             if (result != null) {
                 when (plugin) {
                     is DestinationPlugin -> {
-                        plugin.process(result)
-                    }
-                    is EventPlugin -> {
-                        when (result) {
-                            is IdentifyEvent -> {
-                                result = plugin.identify(result as IdentifyEvent)
-                            }
-                            is TrackEvent -> {
-                                result = plugin.track(result as TrackEvent)
-                            }
-                            is GroupEvent -> {
-                                result = plugin.group(result as GroupEvent)
-                            }
-                            is ScreenEvent -> {
-                                result = plugin.screen(result as ScreenEvent)
-                            }
-                            is AliasEvent -> {
-                                result = plugin.alias(result as AliasEvent)
-                            }
-                        }
+                        plugin.execute(result!!)
                     }
                     else -> {
-                        result = plugin.execute(result as BaseEvent)
+                        result = plugin.execute(result!!)
                     }
                 }
             }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Plugin.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Plugin.kt
@@ -70,6 +70,14 @@ interface EventPlugin : Plugin {
         return payload
     }
 
+    override fun execute(event: BaseEvent): BaseEvent? = when (event) {
+        is IdentifyEvent -> identify(event)
+        is TrackEvent -> track(event)
+        is GroupEvent -> group(event)
+        is ScreenEvent -> screen(event)
+        is AliasEvent -> alias(event)
+    }
+
     open fun flush() {}
 
     open fun reset() {}
@@ -143,9 +151,7 @@ abstract class DestinationPlugin : EventPlugin {
         return afterResult
     }
 
-    final override fun execute(event: BaseEvent): BaseEvent? {
-        return null
-    }
+    final override fun execute(event: BaseEvent): BaseEvent? = process(event)
 
     internal fun isDestinationEnabled(event: BaseEvent?): Boolean {
         // if event payload has integration marked false then its disabled by customer

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/StartupQueue.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/StartupQueue.kt
@@ -4,7 +4,6 @@ import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.BaseEvent
 import com.segment.analytics.kotlin.core.System
 import com.segment.analytics.kotlin.core.platform.Plugin
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import com.segment.analytics.kotlin.core.platform.plugins.logger.*
 import sovran.kotlin.Subscriber
@@ -65,9 +64,8 @@ class StartupQueue : Plugin, Subscriber {
 
     private fun replayEvents() {
         // replay the queued events to the instance of Analytics we're working with.
-        for (event in queuedEvents) {
-            analytics.process(event)
+        while(!queuedEvents.isEmpty()) {
+            analytics.process(queuedEvents.poll())
         }
-        queuedEvents.clear()
     }
 }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
@@ -5,7 +5,6 @@ import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.platform.plugins.ContextPlugin
 import com.segment.analytics.kotlin.core.utils.*
 import io.mockk.*
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -90,7 +89,7 @@ class AnalyticsTests {
         }
 
         @Test
-        fun `analytics should respect remote apiHost`() = runTest {
+        fun `analytics should respect remote apiHost`() {
             // need the following block in `init` to inject mock before analytics gets instantiate
             val settingsStream = ByteArrayInputStream(
                 """
@@ -107,7 +106,6 @@ class AnalyticsTests {
                 apiHost = "local"
             )
             analytics = testAnalytics(config, testScope, testDispatcher)
-            delay(1000)
             analytics.track("test")
             analytics.flush()
 

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
@@ -5,6 +5,7 @@ import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.platform.plugins.ContextPlugin
 import com.segment.analytics.kotlin.core.utils.*
 import io.mockk.*
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -89,7 +90,7 @@ class AnalyticsTests {
         }
 
         @Test
-        fun `analytics should respect remote apiHost`() {
+        fun `analytics should respect remote apiHost`() = runTest {
             // need the following block in `init` to inject mock before analytics gets instantiate
             val settingsStream = ByteArrayInputStream(
                 """
@@ -106,6 +107,7 @@ class AnalyticsTests {
                 apiHost = "local"
             )
             analytics = testAnalytics(config, testScope, testDispatcher)
+            delay(1000)
             analytics.track("test")
             analytics.flush()
 

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
@@ -88,6 +88,7 @@ class AnalyticsTests {
             assertEquals(exception.message?.contains("Android"), true)
         }
 
+        @Disabled
         @Test
         fun `analytics should respect remote apiHost`() {
             // need the following block in `init` to inject mock before analytics gets instantiate
@@ -114,6 +115,7 @@ class AnalyticsTests {
             assertEquals("remote", apiHost.captured)
         }
 
+        @Disabled
         @Test
         fun `analytics should respect local modified apiHost if remote not presented`() {
             val config = Configuration(

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/utils/Plugins.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/utils/Plugins.kt
@@ -25,6 +25,7 @@ class TestRunPlugin(var closure: (BaseEvent?) -> Unit): EventPlugin {
     }
 
     override fun execute(event: BaseEvent): BaseEvent {
+        super.execute(event)
         updateState(true)
         return event
     }


### PR DESCRIPTION
* address event plugin `execute` disparity between swift and kotlin
* fix issue that event being lost if tracked right after sdk initialization