### PR TITLE
add `middlewareSettings` to Settings data object

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -22,6 +22,7 @@ data class Settings(
     var integrations: JsonObject = emptyJsonObject,
     var plan: JsonObject = emptyJsonObject,
     var edgeFunction: JsonObject = emptyJsonObject,
+    var middlewareSettings: JsonObject = emptyJsonObject,
 ) {
     inline fun <reified T : Any> destinationSettings(
         name: String,

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
@@ -3,22 +3,33 @@ package com.segment.analytics.kotlin.core
 import com.segment.analytics.kotlin.core.platform.DestinationPlugin
 import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.platform.plugins.ContextPlugin
-import com.segment.analytics.kotlin.core.utils.*
-import io.mockk.*
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import com.segment.analytics.kotlin.core.utils.StubPlugin
+import com.segment.analytics.kotlin.core.utils.TestRunPlugin
+import com.segment.analytics.kotlin.core.utils.clearPersistentStorage
+import com.segment.analytics.kotlin.core.utils.mockHTTPClient
+import com.segment.analytics.kotlin.core.utils.testAnalytics
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayInputStream
 import java.net.HttpURLConnection
 import java.time.Instant
@@ -469,7 +480,8 @@ class AnalyticsTests {
                 put("int2", false)
             },
             plan = emptyJsonObject,
-            edgeFunction = emptyJsonObject
+            edgeFunction = emptyJsonObject,
+            middlewareSettings = emptyJsonObject
         )
         analytics.store.dispatch(System.UpdateSettingsAction(settings), System::class)
         assertEquals(settings, analytics.settings())

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/SettingsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/SettingsTests.kt
@@ -7,8 +7,8 @@ import com.segment.analytics.kotlin.core.utils.mockHTTPClient
 import com.segment.analytics.kotlin.core.utils.testAnalytics
 import io.mockk.spyk
 import io.mockk.verify
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
@@ -54,7 +54,8 @@ class SettingsTests {
                         buildJsonObject { put("apiKey", "1vNgUqwJeCHmqgI9S1sOm9UHCyfYqbaQ") })
                 },
                 plan = emptyJsonObject,
-                edgeFunction = emptyJsonObject
+                edgeFunction = emptyJsonObject,
+                middlewareSettings = emptyJsonObject
             ),
             curSettings
         )
@@ -78,7 +79,8 @@ class SettingsTests {
                             })
                     },
                     plan = emptyJsonObject,
-                    edgeFunction = emptyJsonObject
+                    edgeFunction = emptyJsonObject,
+                    middlewareSettings = emptyJsonObject
                 ),
                 Plugin.UpdateType.Initial
             )

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/compat/JavaAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/compat/JavaAnalyticsTest.kt
@@ -1,18 +1,38 @@
 package com.segment.analytics.kotlin.core.compat
 
-import com.segment.analytics.kotlin.core.*
+import com.segment.analytics.kotlin.core.AliasEvent
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.Constants
+import com.segment.analytics.kotlin.core.GroupEvent
+import com.segment.analytics.kotlin.core.IdentifyEvent
+import com.segment.analytics.kotlin.core.ScreenEvent
+import com.segment.analytics.kotlin.core.Settings
+import com.segment.analytics.kotlin.core.System
+import com.segment.analytics.kotlin.core.TrackEvent
+import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.platform.DestinationPlugin
 import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.platform.plugins.ContextPlugin
-import com.segment.analytics.kotlin.core.utils.*
-import io.mockk.*
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import com.segment.analytics.kotlin.core.utils.StubPlugin
+import com.segment.analytics.kotlin.core.utils.TestRunPlugin
+import com.segment.analytics.kotlin.core.utils.mockHTTPClient
+import com.segment.analytics.kotlin.core.utils.testAnalytics
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -458,7 +478,8 @@ internal class JavaAnalyticsTest {
                 put("int2", false)
             },
             plan = emptyJsonObject,
-            edgeFunction = emptyJsonObject
+            edgeFunction = emptyJsonObject,
+            middlewareSettings = emptyJsonObject
         )
         analytics.store.dispatch(System.UpdateSettingsAction(settings), System::class)
         assertEquals(settings, analytics.settings())

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/StorageImplTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/StorageImplTest.kt
@@ -9,8 +9,8 @@ import com.segment.analytics.kotlin.core.UserInfo
 import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.utils.clearPersistentStorage
 import com.segment.analytics.kotlin.core.utils.spyStore
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -108,7 +108,8 @@ internal class StorageImplTest {
                                 })
                         },
                         plan = emptyJsonObject,
-                        edgeFunction = emptyJsonObject
+                        edgeFunction = emptyJsonObject,
+                        middlewareSettings = emptyJsonObject
                     ),
                     running = false,
                     initialSettingsDispatched = false
@@ -126,7 +127,8 @@ internal class StorageImplTest {
                         buildJsonObject { put("apiKey", "1vNgUqwJeCHmqgI9S1sOm9UHCyfYqbaQ") })
                 },
                 plan = emptyJsonObject,
-                edgeFunction = emptyJsonObject
+                edgeFunction = emptyJsonObject,
+                middlewareSettings = emptyJsonObject
             ), Json.decodeFromString(Settings.serializer(), settings)
         )
     }


### PR DESCRIPTION
Add `middlewareSettings` to Settings data object as fetched from [here](https://cdn-settings.segment.com/v1/projects/TyqsdyrGOiRIXIcCyUsITMneLyHL0xIg/settings)

```json
{
  "integrations": {
    "Segment.io": {
      "apiKey": "TyqsdyrGOiRIXIcCyUsITMneLyHL0xIg",
      "unbundledIntegrations": [
        
      ],
      "addBundledMetadata": true,
      "maybeBundledConfigIds": {
        
      },
      "versionSettings": {
        "version": "4.4.7",
        "componentTypes": [
          "browser"
        ]
      }
    }
  },
  "plan": {
    "track": {
      "__default": {
        "enabled": true,
        "integrations": {
          
        }
      }
    },
    "identify": {
      "__default": {
        "enabled": true
      }
    },
    "group": {
      "__default": {
        "enabled": true
      }
    }
  },
  "edgeFunction": {
    
  },
  "analyticsNextEnabled": false,
  "middlewareSettings": {
    
  },
  "enabledMiddleware": {
    
  },
  "metrics": {
    "sampleRate": 0.1
  },
  "legacyVideoPluginsEnabled": false,
  "remotePlugins": [
    
  ]
}
```