### PR TITLE
add api for identify using only traits

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/compat/JavaAnalytics.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/compat/JavaAnalytics.kt
@@ -115,6 +115,41 @@ class JavaAnalytics private constructor() {
     fun identify(userId: String, serializable: JsonSerializable) = analytics.identify(userId, serializable.serialize())
 
     /**
+     * Identify lets you record {@code traits} about the user, like their email, name, account type,
+     * etc.
+     *
+     * <p>Traits and userId will be automatically cached and available on future sessions for the
+     * same user. To update a trait on the server, call identify with the same user id (or null).
+     * You can also use {@link #identify(Traits)} for this purpose.
+     *
+     * In the case when user logs out, make sure to call {@link #reset()} to clear user's identity
+     * info.
+     *
+     * @param traits [Traits] about the user in JsonObject form. can be built by
+     *          {@link Builder com.segment.analytics.kotlin.core.compat.Builder}
+     * @see <a href="https://segment.com/docs/spec/identify/">Identify Documentation</a>
+     */
+    @JvmOverloads
+    fun identify(traits: JsonObject = emptyJsonObject) = analytics.identify(traits)
+
+    /**
+     * Identify lets you record {@code traits} about the user, like their email, name, account type,
+     * etc.
+     *
+     * <p>Traits and userId will be automatically cached and available on future sessions for the
+     * same user. To update a trait on the server, call identify with the same user id (or null).
+     * You can also use {@link #identify(Traits)} for this purpose.
+     *
+     * In the case when user logs out, make sure to call {@link #reset()} to clear user's identity
+     * info.
+     *
+     * @param serializable an object that implements {@link JsonSerializable com.segment.analytics.kotlin.core.compat.JsonSerializable}
+     * @see <a href="https://segment.com/docs/spec/identify/">Identify Documentation</a>
+     */
+    fun identify(serializable: JsonSerializable) = analytics.identify(serializable.serialize())
+
+
+    /**
      * The screen methods let your record whenever a user sees a screen of your mobile app, and
      * attach a name, category or properties to the screen. Either category or name must be
      * provided.

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/AnalyticsTests.kt
@@ -291,6 +291,35 @@ class AnalyticsTests {
                     ), newUserInfo
                 )
             }
+
+            @Test
+            fun `identify() overwrites traits`() = runTest  {
+                analytics.store.dispatch(
+                    UserInfo.SetUserIdAndTraitsAction(
+                        "oldUserId",
+                        buildJsonObject { put("behaviour", "bad") }),
+                    UserInfo::class
+                )
+                val curUserInfo = analytics.store.currentState(UserInfo::class)
+                assertEquals(
+                    UserInfo(
+                        userId = "oldUserId",
+                        traits = buildJsonObject { put("behaviour", "bad") },
+                        anonymousId = "qwerty-qwerty-123"
+                    ), curUserInfo
+                )
+
+                analytics.identify( buildJsonObject { put("behaviour", "good") })
+
+                val newUserInfo = analytics.store.currentState(UserInfo::class)
+                assertEquals(
+                    UserInfo(
+                        userId = "oldUserId",
+                        traits = buildJsonObject { put("behaviour", "good") },
+                        anonymousId = "qwerty-qwerty-123"
+                    ), newUserInfo
+                )
+            }
         }
 
         @Nested

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/compat/JavaAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/compat/JavaAnalyticsTest.kt
@@ -10,6 +10,7 @@ import com.segment.analytics.kotlin.core.ScreenEvent
 import com.segment.analytics.kotlin.core.Settings
 import com.segment.analytics.kotlin.core.System
 import com.segment.analytics.kotlin.core.TrackEvent
+import com.segment.analytics.kotlin.core.UserInfo
 import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.platform.DestinationPlugin
 import com.segment.analytics.kotlin.core.platform.Plugin
@@ -345,6 +346,39 @@ internal class JavaAnalyticsTest {
             verify { mockPlugin.identify(capture(identify)) }
             assertEquals(
                 IdentifyEvent(userId, json).populate().apply {
+                    userId = this@Identify.userId
+                },
+                identify.captured
+            )
+        }
+
+        @Test
+        fun `identify with only serializable traits`() = runTest {
+            analytics.store.dispatch(UserInfo.SetUserIdAction(userId), UserInfo::class)
+
+            analytics.add(mockPlugin)
+            analytics.identify(serializable)
+
+            verify { mockPlugin.identify(capture(identify)) }
+            assertEquals(
+                IdentifyEvent("", json).populate().apply {
+                    userId = this@Identify.userId
+                },
+                identify.captured
+            )
+        }
+
+        @Test
+        fun `identify with only json traits`() = runTest {
+            analytics.store.dispatch(UserInfo.SetUserIdAction(userId), UserInfo::class)
+
+            analytics.add(mockPlugin)
+            analytics.identify(json)
+
+            val identify = slot<IdentifyEvent>()
+            verify { mockPlugin.identify(capture(identify)) }
+            assertEquals(
+                IdentifyEvent("", json).populate().apply {
                     userId = this@Identify.userId
                 },
                 identify.captured


### PR DESCRIPTION
Adds new api `fun Analytics.identify(traits)` that allows users to update traits without needing userId