### PR TITLE
Correct minsdkversion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ android {
         // Required when setting minSdkVersion to 20 or lower
         multiDexEnabled true
 
-        minSdkVersion 16
+        minSdkVersion 26
         targetSdkVersion 31
         versionCode VERSION_CODE.toInteger()
         versionName VERSION_NAME

--- a/samples/java-android-app/build.gradle
+++ b/samples/java-android-app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.segment.analytics.javaandroidapp"
-        minSdkVersion 16
+        minSdkVersion 26
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"

--- a/samples/kotlin-android-app-destinations/build.gradle
+++ b/samples/kotlin-android-app-destinations/build.gradle
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         multiDexEnabled true
         applicationId "com.segment.analytics.kotlin.destinations"
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdkVersion 31
         versionCode 3
         versionName "2.0"

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         multiDexEnabled true
         applicationId "com.segment.analytics.next"
-        minSdkVersion 19
+        minSdkVersion 26
         targetSdkVersion 31
         versionCode 3
         versionName "2.0"


### PR DESCRIPTION
Our timestamps [rely](https://github.com/segmentio/analytics-kotlin/blob/ed398f090cafb98d42a93ff4c5c4cff4b1323885/core/src/main/java/com/segment/analytics/kotlin/core/Events.kt#L13) on this class: https://developer.android.com/reference/java/time/Instant.html

Which requires API level 26 or above, changing our minSdkVersion to reflect this.