### PR TITLE
Add shutdown function to Analytics to free resources.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,8 +54,8 @@ dependencies {
     api project(':core')
     api 'com.segment:sovran-kotlin:1.2.1'
     api "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
     implementation 'androidx.lifecycle:lifecycle-process:2.4.0'
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.4.0'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,14 +15,14 @@ test {
 
 dependencies {
     // MAIN DEPS
-    api 'com.segment:sovran-kotlin:1.2.1'
+    api 'com.segment:sovran-kotlin:1.2.2'
     api "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
 
     // TESTING
     repositories { mavenCentral() }
     testImplementation 'io.mockk:mockk:1.10.6'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
 
     testImplementation platform("org.junit:junit-bom:5.7.2")
     testImplementation "org.junit.jupiter:junit-jupiter"

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
@@ -9,11 +9,7 @@ import com.segment.analytics.kotlin.core.platform.plugins.SegmentDestination
 import com.segment.analytics.kotlin.core.platform.plugins.StartupQueue
 import com.segment.analytics.kotlin.core.platform.plugins.logger.SegmentLog
 import com.segment.analytics.kotlin.core.platform.plugins.logger.log
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.Json
@@ -83,11 +79,11 @@ open class Analytics protected constructor(
         object : CoroutineConfiguration {
             override val store = Store()
             override val analyticsScope = CoroutineScope(SupervisorJob())
-            override val analyticsDispatcher =
+            override val analyticsDispatcher : CloseableCoroutineDispatcher =
                 Executors.newCachedThreadPool().asCoroutineDispatcher()
-            override val networkIODispatcher =
+            override val networkIODispatcher : CloseableCoroutineDispatcher =
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            override val fileIODispatcher =
+            override val fileIODispatcher : CloseableCoroutineDispatcher =
                 Executors.newFixedThreadPool(2).asCoroutineDispatcher()
         })
 
@@ -533,6 +529,23 @@ open class Analytics protected constructor(
                 (it as? EventPlugin)?.reset()
             }
         }
+    }
+
+    /**
+     * Shuts down the library by freeing up resources includes queues and Threads. This is a
+     * non-reversible operation. This instance of Analytics will be shutdown and no longer process
+     * events.
+     *
+     * Should only be called in containerized environments where you need to free resources like
+     * CoroutineDispatchers and ExecutorService instances so they allow the container to shutdown
+     * properly.
+     */
+    fun shutdown() {
+        (analyticsDispatcher as CloseableCoroutineDispatcher).close()
+        (networkIODispatcher as CloseableCoroutineDispatcher).close()
+        (fileIODispatcher as CloseableCoroutineDispatcher).close()
+
+        store.shutdown();
     }
 
     /**


### PR DESCRIPTION
Add a shutdown() function to Analytics to allow resources to be freed up. This is useful in containerized environments where the container needs to shutdown properly.