### PR TITLE
Feature/add full deep link support to kotlin sample

### DIFF
--- a/android/src/main/java/com/segment/analytics/kotlin/android/AndroidAnalytics.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/AndroidAnalytics.kt
@@ -1,9 +1,11 @@
 package com.segment.analytics.kotlin.android
 
 import android.content.Context
+import android.content.Intent
 import android.util.Log
 import com.segment.analytics.kotlin.android.plugins.AndroidContextPlugin
 import com.segment.analytics.kotlin.android.plugins.AndroidLifecyclePlugin
+import com.segment.analytics.kotlin.android.utilities.DeepLinkUtils
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.Configuration
 import com.segment.analytics.kotlin.core.platform.plugins.logger.*
@@ -66,6 +68,10 @@ private fun Analytics.startup() {
     add(AndroidLifecyclePlugin())
     add(AndroidLogTarget(), LoggingType.log)
     remove(targetType = ConsoleTarget::class)
+}
+
+fun Analytics.Companion.addDeepLinkOpen(analytics: Analytics, referrer: String?, intent: Intent?) {
+    DeepLinkUtils(analytics).trackDeepLinkManually(analytics, referrer, intent)
 }
 
 class AndroidLogTarget: LogTarget {

--- a/android/src/main/java/com/segment/analytics/kotlin/android/AndroidAnalytics.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/AndroidAnalytics.kt
@@ -71,7 +71,7 @@ private fun Analytics.startup() {
 }
 
 fun Analytics.Companion.addDeepLinkOpen(analytics: Analytics, referrer: String?, intent: Intent?) {
-    DeepLinkUtils(analytics).trackDeepLinkManually(analytics, referrer, intent)
+    DeepLinkUtils(analytics).trackDeepLinkFrom(referrer, intent)
 }
 
 class AndroidLogTarget: LogTarget {

--- a/android/src/main/java/com/segment/analytics/kotlin/android/AndroidAnalytics.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/AndroidAnalytics.kt
@@ -70,8 +70,18 @@ private fun Analytics.startup() {
     remove(targetType = ConsoleTarget::class)
 }
 
-fun Analytics.Companion.addDeepLinkOpen(analytics: Analytics, referrer: String?, intent: Intent?) {
-    DeepLinkUtils(analytics).trackDeepLinkFrom(referrer, intent)
+/**
+ * Track a deep link manually.
+ *
+ * This function is meant to be called by the user in places were we need to manually track a
+ * deep link opened event. For example, in the cause of an Activity being sent a new intent in it's
+ * onNewIntent() function. The URI that triggered the intent will be in the Intent.data property.
+ *
+ * @param referrer: The string representing the app or url that caused the deep link to be activated.
+ * @param intent: The intent received by the Activity's onNewIntent() function.
+ */
+fun Analytics.trackDeepLinkOpen(referrer: String?, intent: Intent?) {
+    DeepLinkUtils(this).trackDeepLinkFrom(referrer, intent)
 }
 
 class AndroidLogTarget: LogTarget {

--- a/android/src/main/java/com/segment/analytics/kotlin/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/plugins/AndroidLifecyclePlugin.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.segment.analytics.kotlin.android.utilities.DeepLinkUtils
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.Storage
 import com.segment.analytics.kotlin.core.platform.Plugin
@@ -211,27 +212,11 @@ class AndroidLifecyclePlugin() : Application.ActivityLifecycleCallbacks, Default
 
     private fun trackDeepLink(activity: Activity?) {
         val intent = activity?.intent
-        if (intent == null || intent.data == null) {
-            return
-        }
-        val properties = buildJsonObject {
 
-            getReferrer(activity)?.let {
-                put("referrer", it.toString())
-            }
-
-            val uri = intent.data
-            uri?.let {
-                for (parameter in uri.queryParameterNames) {
-                    val value = uri.getQueryParameter(parameter)
-                    if (value != null && value.trim().isNotEmpty()) {
-                        put(parameter, value)
-                    }
-                }
-                put("url", uri.toString())
-            }
+        intent?.let {
+            val referrer = getReferrer(activity)?.toString()
+            DeepLinkUtils(analytics).trackDeepLinkFrom(referrer, it)
         }
-        analytics.track("Deep Link Opened", properties)
     }
 
     internal fun trackApplicationLifecycleEvents() {

--- a/android/src/main/java/com/segment/analytics/kotlin/android/utilities/DeepLinkUtils.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/utilities/DeepLinkUtils.kt
@@ -1,0 +1,43 @@
+package com.segment.analytics.kotlin.android.utilities
+
+import android.content.Intent
+import com.segment.analytics.kotlin.core.Analytics
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class DeepLinkUtils(val analytics: Analytics) {
+
+    fun trackDeepLinkFrom(referrer: String?, intent: Intent?) {
+
+        if (intent == null || intent.data == null) {
+            return
+        }
+
+        val properties = buildJsonObject {
+
+            referrer?.let {
+                put("referrer", it)
+            }
+
+            val uri = intent.data
+            uri?.let {
+                for (parameter in uri.queryParameterNames) {
+                    val value = uri.getQueryParameter(parameter)
+                    if (value != null && value.trim().isNotEmpty()) {
+                        put(parameter, value)
+                    }
+                }
+                put("url", uri.toString())
+            }
+        }
+        analytics.track("Deep Link Opened", properties)
+    }
+
+    /**
+     * Manually track Deep Links.
+     */
+    fun trackDeepLinkManually(analytics: Analytics, referrer: String?, intent: Intent?) {
+        DeepLinkUtils(analytics).trackDeepLinkFrom(referrer, intent)
+    }
+
+}

--- a/android/src/main/java/com/segment/analytics/kotlin/android/utilities/DeepLinkUtils.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/utilities/DeepLinkUtils.kt
@@ -32,12 +32,4 @@ class DeepLinkUtils(val analytics: Analytics) {
         }
         analytics.track("Deep Link Opened", properties)
     }
-
-    /**
-     * Manually track Deep Links.
-     */
-    fun trackDeepLinkManually(analytics: Analytics, referrer: String?, intent: Intent?) {
-        DeepLinkUtils(analytics).trackDeepLinkFrom(referrer, intent)
-    }
-
 }

--- a/samples/kotlin-android-app/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="ca-app-pub-3940256099942544~3347511713" />
         <activity android:name=".MainActivity"
+            android:launchMode="singleInstance"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -38,9 +39,12 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
+                <!-- Trigger Deep-link from cmd line:
+                adb shell am start -a android.intent.action.VIEW -c android.intent.category.DEFAULT -d "seg://segment-sample.com"
+                -->
                 <data
                     android:host="segment-sample.com"
-                    android:scheme="https" />
+                    android:scheme="seg" />
             </intent-filter>
         </activity>
         <service

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
-import com.segment.analytics.kotlin.android.addDeepLinkOpen
+import com.segment.analytics.kotlin.android.trackDeepLinkOpen
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.EventType
 import com.segment.analytics.kotlin.core.platform.plugins.logger.log
@@ -58,14 +58,13 @@ class MainActivity : AppCompatActivity() {
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
 
-        // Add a manual deep-link opened event.
+        // Add a deep-link opened event manually.
         // This is necessary when your Activity has a android:launchMode of
         // 'singleInstance', 'singleInstancePerTask', 'singleTop', or any other mode
         // that will re-use an existing Activity instead of creating a new instance.
         // The Analytics SDK automatically identifies when you app is started from a deep link
         // if the Activity is created, but not if it is re-used. Therefore we have to add this
         // code to manually capture the Deep Link info.
-
-        Analytics.addDeepLinkOpen(analytics, "deep-link", intent)
+        analytics.trackDeepLinkOpen("deep-link", intent)
     }
 }

--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/MainActivity.kt
@@ -1,11 +1,13 @@
 package com.segment.analytics.next
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import com.segment.analytics.kotlin.android.addDeepLinkOpen
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.EventType
 import com.segment.analytics.kotlin.core.platform.plugins.logger.log
@@ -51,5 +53,19 @@ class MainActivity : AppCompatActivity() {
         // replace the FrameLayout with new Fragment
         fragmentTransaction.replace(R.id.frameLayout, fragment)
         fragmentTransaction.commit() // save the changes
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+
+        // Add a manual deep-link opened event.
+        // This is necessary when your Activity has a android:launchMode of
+        // 'singleInstance', 'singleInstancePerTask', 'singleTop', or any other mode
+        // that will re-use an existing Activity instead of creating a new instance.
+        // The Analytics SDK automatically identifies when you app is started from a deep link
+        // if the Activity is created, but not if it is re-used. Therefore we have to add this
+        // code to manually capture the Deep Link info.
+
+        Analytics.addDeepLinkOpen(analytics, "deep-link", intent)
     }
 }


### PR DESCRIPTION
Add full support for deep links in Kotlin Analytics. 

This adds a new top-level API `addDeepLinkOpen()` function to the Analytics functions that people will use to manually track the app opening from a deep link.