### PR TITLE
Kotlin sample app: Fix Null Pointer Exception when rotating the screen.

### DIFF
--- a/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/plugins/PushNotificationTracking.kt
+++ b/samples/kotlin-android-app/src/main/java/com/segment/analytics/next/plugins/PushNotificationTracking.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.json.put
  * opening of that notification and fire the Push Notification Tapped event.
  */
 
-object PushNotificationTracking: Plugin, AndroidLifecycle {
+object PushNotificationTracking : Plugin, AndroidLifecycle {
     override val type: Plugin.Type = Plugin.Type.Utility
     override lateinit var analytics: Analytics
 
@@ -25,8 +25,12 @@ object PushNotificationTracking: Plugin, AndroidLifecycle {
             activity?.intent?.extras
         } else {
             Bundle().apply {
-                putAll(savedInstanceState)
-                putAll(activity?.intent?.extras)
+                if (savedInstanceState != null) {
+                    putAll(savedInstanceState)
+                }
+                if (activity?.intent?.extras != null) {
+                    putAll(activity?.intent?.extras)
+                }
             }
         }
         checkPushNotification(bundle)


### PR DESCRIPTION
The sample Kotlin app will crash on screen rotation because we would put null values into the Bundle:

```
Bundle() { put(..., null) } }
```

This would cause an issue later as the OS would try to unparcel the bundle and not handle the null value well:

```
FATAL EXCEPTION: pool-10-thread-6
Process: com.segment.analytics.next, PID: 31741
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.os.Bundle.unparcel()' on a null object reference
```

