### PR TITLE
Use a CopyOnWriteArrayList in Mediator instead of synchronized {}.

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Timeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Timeline.kt
@@ -4,6 +4,7 @@ import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.BaseEvent
 import com.segment.analytics.kotlin.core.System
 import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.reflect.KClass
 
 // Platform abstraction for managing all plugins and their execution
@@ -11,11 +12,11 @@ import kotlin.reflect.KClass
 //      Before -> Enrichment -> Destination -> After
 internal class Timeline {
     internal val plugins: Map<Plugin.Type, Mediator> = mapOf(
-        Plugin.Type.Before to Mediator(mutableListOf()),
-        Plugin.Type.Enrichment to Mediator(mutableListOf()),
-        Plugin.Type.Destination to Mediator(mutableListOf()),
-        Plugin.Type.After to Mediator(mutableListOf()),
-        Plugin.Type.Utility to Mediator(mutableListOf())
+        Plugin.Type.Before to Mediator(CopyOnWriteArrayList()),
+        Plugin.Type.Enrichment to Mediator(CopyOnWriteArrayList()),
+        Plugin.Type.Destination to Mediator(CopyOnWriteArrayList()),
+        Plugin.Type.After to Mediator(CopyOnWriteArrayList()),
+        Plugin.Type.Utility to Mediator(CopyOnWriteArrayList())
     )
     lateinit var analytics: Analytics
 


### PR DESCRIPTION
Remove synchronize {} from all Mediator functions. Replaced the MutableList with a CopyOnWriteArrayList, that will allow multiple readers of list at once and caller that modifies the list (add,remove, etc) will get a new copy of the list that will automatically synchronized by the JVM in a safe way.

See: https://developer.android.com/reference/kotlin/java/util/concurrent/CopyOnWriteArrayList


Note: It looks to me that this has greatly sped up sending events through the timeline.