### PR TITLE
Also check the legacy build indicator when deciding if this a new App Install

### DIFF
--- a/android/src/main/java/com/segment/analytics/kotlin/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/plugins/AndroidLifecyclePlugin.kt
@@ -228,9 +228,10 @@ class AndroidLifecyclePlugin() : Application.ActivityLifecycleCallbacks, Default
         // Get the previous recorded version.
         val previousVersion = storage.read(Storage.Constants.AppVersion)
         val previousBuild = storage.read(Storage.Constants.AppBuild)
+        val legacyPreviousBuild = storage.read(Storage.Constants.LegacyAppBuild)
 
         // Check and track Application Installed or Application Updated.
-        if (previousBuild == null) {
+        if (previousBuild == null && legacyPreviousBuild == null) {
             analytics.track(
                 "Application Installed",
                 buildJsonObject {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Storage.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Storage.kt
@@ -37,6 +37,7 @@ interface Storage {
         Events("segment.events"),
         AppVersion("segment.app.version"),
         AppBuild("segment.app.build"),
+        LegacyAppBuild("build"),
         DeviceId("segment.device.id")
     }
 


### PR DESCRIPTION
This fixes an issue where an app update that upgraded from analytics-android to analytics-kotlin would look like a new app install instead of an upgrade.