### PR TITLE
retrieve the legacy build number as an integer instead of a string.

### DIFF
--- a/android/src/main/java/com/segment/analytics/kotlin/android/Storage.kt
+++ b/android/src/main/java/com/segment/analytics/kotlin/android/Storage.kt
@@ -71,6 +71,17 @@ class AndroidStorage(
             Storage.Constants.Events -> {
                 eventsFile.read().joinToString()
             }
+            Storage.Constants.LegacyAppBuild -> {
+                // The legacy app build number was stored as an integer so we have to get it
+                // as an integer and convert it to a String.
+                val noBuild = -1
+                val build = sharedPreferences.getInt(key.rawVal, noBuild)
+                if (build != noBuild) {
+                    return build.toString()
+                } else {
+                    return null
+                }
+            }
             else -> {
                 sharedPreferences.getString(key.rawVal, null)
             }


### PR DESCRIPTION
Found an error when I tested this tomorrow while working on something else.

I was reading the legacy build as a String, but it was stored as an Integer, but while you might expect this to work, it actually throws a runtime exception and crashes the app. 

So now instead we'll have to retrieve the legacy build number as an Integer.