### PR TITLE
Use copies of Events in the Mediator instead of referring to the same…

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Mediator.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Mediator.kt
@@ -30,7 +30,7 @@ internal class Mediator(internal var plugins: CopyOnWriteArrayList<Plugin> = Cop
 
         plugins.forEach { plugin ->
             result?.let {
-                var copy = it.copy<BaseEvent>()
+                val copy = it.copy<BaseEvent>()
                 try {
                     when (plugin) {
                         is DestinationPlugin -> {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Mediator.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Mediator.kt
@@ -30,13 +30,14 @@ internal class Mediator(internal var plugins: CopyOnWriteArrayList<Plugin> = Cop
 
         plugins.forEach { plugin ->
             result?.let {
+                var copy = it.copy<BaseEvent>()
                 try {
                     when (plugin) {
                         is DestinationPlugin -> {
-                            plugin.execute(it)
+                            plugin.execute(copy)
                         }
                         else -> {
-                            result = plugin.execute(it)
+                            result = plugin.execute(copy)
                         }
                     }
                 } catch (t: Throwable) {

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/plugins/DestinationPluginTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/platform/plugins/DestinationPluginTests.kt
@@ -155,7 +155,9 @@ class DestinationPluginTests {
 
         val result = timeline.process(trackEvent)
 
-        assertEquals(expected, result)
+        assertEquals(expected.type, result?.type)
+        assertEquals(expected.event, (result as TrackEvent).event)
+        assertEquals(expected.properties, (result as TrackEvent).properties)
     }
 
     @Test


### PR DESCRIPTION
… event which has side-effect issues.