### PR TITLE
Locale Timestamp

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/DateTimeUtils.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/DateTimeUtils.kt
@@ -12,7 +12,7 @@ import java.util.*
  * dateTimeNowString(): 2023-04-19T04:03:46.880Z
  */
 fun dateTimeNowString(): String {
-    val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.'Szzz")
+    val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.'Szzz", Locale.ROOT)
     val utc = TimeZone.getTimeZone("UTC");
     sdf.timeZone = utc;
     return sdf.format(Date()).replace("UTC", "Z")

--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/DateTimeUtils.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/DateTimeUtils.kt
@@ -12,6 +12,8 @@ import java.util.*
  * dateTimeNowString(): 2023-04-19T04:03:46.880Z
  */
 fun dateTimeNowString(): String {
+    // Note, we should specify locale = Locale.ROOT, otherwise the timestamp returned will use
+    // the default locale, which may not be what we want.
     val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.'Szzz", Locale.ROOT)
     val utc = TimeZone.getTimeZone("UTC");
     sdf.timeZone = utc;

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/DateTimeUtilsTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/DateTimeUtilsTest.kt
@@ -1,0 +1,5 @@
+package com.segment.analytics.kotlin.core.utilities
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class DateTimeUtilsTest

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/DateTimeUtilsTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/DateTimeUtilsTest.kt
@@ -1,5 +1,14 @@
 package com.segment.analytics.kotlin.core.utilities
 
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
-internal class DateTimeUtilsTest
+class DateTimeUtilsTest {
+
+    @Test
+    fun `dateTimeNowString() produces a string in the correct format`() {
+        val dateTimeNowString = dateTimeNowString()
+        val regex = Regex("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:\\d{2}\\.\\d{3}Z$")
+        assertTrue(regex.matches(dateTimeNowString))
+    }
+}

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/DateTimeUtilsTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/DateTimeUtilsTest.kt
@@ -1,14 +1,15 @@
 package com.segment.analytics.kotlin.core.utilities
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
+import java.time.format.DateTimeFormatter.ISO_DATE_TIME
 
 class DateTimeUtilsTest {
 
     @Test
-    fun `dateTimeNowString() produces a string in the correct format`() {
+    fun `dateTimeNowString() produces a string in the correct ISO8601 format`() {
         val dateTimeNowString = dateTimeNowString()
-        val regex = Regex("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:\\d{2}\\.\\d{3}Z$")
-        assertTrue(regex.matches(dateTimeNowString))
+        val date = ISO_DATE_TIME.parse(dateTimeNowString)
+        assertNotNull(date)
     }
 }


### PR DESCRIPTION
On Android, if you set the app language to `Arabic` the timestamp will be formatted using the device locale, i.e. `٠٥T١٠:٤٨:٢٩.٥Z`. I've attached screenshots of the behavior before / after the changes

**Before / After (Arabic)**

<img src="https://github.com/segmentio/analytics-kotlin/assets/14003063/7fb86597-6888-4a74-b32a-0f4218454475" width=300 /> <img src="https://github.com/segmentio/analytics-kotlin/assets/14003063/ac8ca2da-1748-48d1-84f4-eae57ba6c2e6" width=300 />

**Before / After (English)**

<img src="https://github.com/segmentio/analytics-kotlin/assets/14003063/af673f41-5a6b-42a3-9c80-5281b3b91e87" width=300 /> <img src="https://github.com/segmentio/analytics-kotlin/assets/14003063/f58967ff-a36d-4de9-9703-fe6732d392be" width=300 />