### PR TITLE
Set defaultSettings config option to a var

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Configuration.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Configuration.kt
@@ -33,7 +33,7 @@ data class Configuration(
     var flushAt: Int = 20,
     var flushInterval: Int = 30,
     var flushPolicies: List<FlushPolicy> = emptyList<FlushPolicy>(),
-    val defaultSettings: Settings = Settings(),
+    var defaultSettings: Settings = Settings(),
     var autoAddSegmentDestination: Boolean = true,
     var apiHost: String = DEFAULT_API_HOST,
     var cdnHost: String = DEFAULT_CDN_HOST,


### PR DESCRIPTION
Despite being a config option when initializing an analytics instance, defaultSettings cannot be assigned due to it being a val. 
As per Kotlin’s docs: https://developer.android.com/kotlin/learn#:~:text=Kotlin%20uses%20two%20different%20keywords,variable%20whose%20value%20can%20change. 

Kotlin uses two different keywords to declare variables: val and var.

Use val for a variable whose value never changes. You can't reassign a value to a variable that was declared using val.

Use var for a variable whose value can change.

![image](https://github.com/segmentio/analytics-kotlin/assets/16934916/8d231dde-32f1-43b9-b9f0-f7656eb22022)
