### PR TITLE
Fix "not initialized" Exception

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/Timeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/Timeline.kt
@@ -71,7 +71,7 @@ internal class Timeline {
                 Telemetry.INTEGRATION_ERROR_METRIC, t.stackTraceToString()) {
                 it["error"] = t.toString()
                 it["plugin"] = "${plugin.type}-${plugin.javaClass}"
-                it["writekey"] = plugin.analytics.configuration.writeKey
+                it["writekey"] = analytics.configuration.writeKey
                 it["message"] = "Exception executing plugin"
             }
         }


### PR DESCRIPTION
fix: don't use plugin's analytics object if setup threw an Exception because it might not be initiated.