### PR TITLE
Adding the consentSettings property so that we can access it directly…

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -23,6 +23,7 @@ data class Settings(
     var edgeFunction: JsonObject = emptyJsonObject,
     var middlewareSettings: JsonObject = emptyJsonObject,
     var metrics: JsonObject = emptyJsonObject,
+    var consentSettings: JsonObject = emptyJsonObject
 ) {
     inline fun <reified T : Any> destinationSettings(
         name: String,


### PR DESCRIPTION
Adding the consentSettings property so that we can access it directly in tests instead of using JSON as workaround.

Downstream projects like analytics-kotlin-consent will now have the ability to set the consentSettings property so that we can add more great tests!