### PR TITLE
Fallback to the defaultSettings if cdn cannot be reached

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -112,7 +112,6 @@ internal fun Analytics.fetchSettings(
     val connection = HTTPClient(writeKey, this.configuration.requestFactory).settings(cdnHost)
     val settingsString =
         connection.inputStream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
-    //configuration.defaultSettings = LenientJson.decodeFromString(settingsString)
     log("Fetched Settings: $settingsString")
     LenientJson.decodeFromString(settingsString)
 } catch (ex: Exception) {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -112,6 +112,7 @@ internal fun Analytics.fetchSettings(
     val connection = HTTPClient(writeKey, this.configuration.requestFactory).settings(cdnHost)
     val settingsString =
         connection.inputStream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
+    //configuration.defaultSettings = LenientJson.decodeFromString(settingsString)
     log("Fetched Settings: $settingsString")
     LenientJson.decodeFromString(settingsString)
 } catch (ex: Exception) {
@@ -121,5 +122,5 @@ internal fun Analytics.fetchSettings(
         it["writekey"] = writeKey
         it["message"] = "Error retrieving settings"
     }
-    null
+    configuration.defaultSettings
 }


### PR DESCRIPTION
Fallback to the default Settings if the CDN cannot be reached. If the app is started with no Internet connection, this will result in an empty settings object:
```
data class Settings(
    var integrations: JsonObject = emptyJsonObject,
    var plan: JsonObject = emptyJsonObject,
    var edgeFunction: JsonObject = emptyJsonObject,
    var middlewareSettings: JsonObject = emptyJsonObject,
    var metrics: JsonObject = emptyJsonObject,
    var consentSettings: JsonObject = emptyJsonObject
) {
```