### PR TITLE
feat: make storage internal and not publicly accessible.

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
@@ -43,7 +43,7 @@ open class Analytics protected constructor(
     }
 
     // use lazy to avoid the instance being leak before fully initialized
-    val storage: Storage by lazy {
+    internal val storage: Storage by lazy {
         configuration.storageProvider.getStorage(
             analytics = this,
             writeKey = configuration.writeKey,


### PR DESCRIPTION
Make `analytics.storage` **internal** so that it is not publicly accessible. 

While this was out of spec with the other libraries and needed to be fixed, it seems to have been this way since v1.0.0 so we might have people in the wild relying on it.

