### PR TITLE
Fix settings not propogate to plugins when offline

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -96,7 +96,13 @@ suspend fun Analytics.checkSettings() {
             settingsObj?.let {
                 log("Dispatching update settings on ${Thread.currentThread().name}")
                 store.dispatch(System.UpdateSettingsAction(settingsObj), System::class)
-                update(settingsObj)
+            }
+
+            store.currentState(System::class)?.let { system ->
+                system.settings?.let { settings ->
+                    log("Propagating settings on ${Thread.currentThread().name}")
+                    update(settings)
+                }
             }
 
             // we're good to go back to a running state.

--- a/gradle/codecov.gradle
+++ b/gradle/codecov.gradle
@@ -29,9 +29,9 @@ task codeCoverageReport(type: JacocoReport) {
     executionData.setFrom(execData)
 
     reports {
-        xml.enabled true
-        xml.destination file("${buildDir}/reports/jacoco/report.xml")
-        html.enabled true
-        csv.enabled false
+        xml.required = true
+        xml.outputLocation = file("${buildDir}/reports/jacoco/report.xml")
+        html.required = true
+        csv.required = false
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 22 15:05:55 PST 2021
+#Tue Jun 24 14:05:08 CDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
* fix the issue that settings not propagate to plugins if there is a network failure
* add a feature to fetch settings whenever app is brought to foreground