### PR TITLE
Fix file descriptor leak in EventPipeline

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
@@ -134,14 +134,13 @@ open class EventPipeline(
             val fileUrlList = parseFilePaths(storage.read(Storage.Constants.Events))
             for (url in fileUrlList) {
                 // upload event file
-                storage.readAsStream(url)?.let { data ->
+                storage.readAsStream(url)?.use { data ->
                     var shouldCleanup = true
                     try {
                         val connection = httpClient.upload(apiHost)
                         connection.outputStream?.let {
                             // Write the payloads into the OutputStream
                             data.copyTo(connection.outputStream)
-                            data.close()
                             connection.outputStream.close()
 
                             // Upload the payloads.


### PR DESCRIPTION
Changed from `.let` to `.use` to ensure `InputStream` is always closed, preventing FD exhaustion when exceptions occur during upload.


This results in serious problems when environments are unable to connect to the Segment API over an extended duration