### PR TITLE
Limit FileEventStream.read() to 1000 files per iteration

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventStream.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/utilities/EventStream.kt
@@ -203,7 +203,12 @@ open class FileEventStream(
         }
     }
 
-    override fun read(): List<String> = (directory.listFiles() ?: emptyArray()).map { it.absolutePath }
+    override fun read(): List<String> = directory.walk()
+        .maxDepth(1)
+        .filter { it.isFile }
+        .take(1000)
+        .map { it.absolutePath }
+        .toList()
 
     /**
      * Remove the given file from disk

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/EventStreamTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/utilities/EventStreamTest.kt
@@ -266,5 +266,43 @@ class EventStreamTest {
             assertEquals("test", files[0])
             assertFalse(eventStream.isOpened)
         }
+
+        @Test
+        fun readLimitsTo1000FilesTest() {
+            // Create 1250 files in the directory
+            for (i in 1..1250) {
+                File(dir, "test$i.tmp").createNewFile()
+            }
+
+            val files = eventStream.read()
+
+            // Verify that read() returns at most 1000 files
+            assertTrue(files.size <= 1000, "Expected at most 1000 files, but got ${files.size}")
+
+            // Verify all returned paths are valid files
+            files.forEach { path ->
+                assertTrue(File(path).exists(), "File $path should exist")
+                assertTrue(File(path).isFile, "Path $path should be a file")
+            }
+        }
+
+        @Test
+        fun readReturnsAllFilesWhenUnder1000Test() {
+            // Create 50 files in the directory
+            for (i in 1..50) {
+                File(dir, "test$i.tmp").createNewFile()
+            }
+
+            val files = eventStream.read()
+
+            // Verify that all 50 files are returned when count is under 1000
+            assertEquals(50, files.size, "Expected 50 files, but got ${files.size}")
+
+            // Verify all returned paths are valid files
+            files.forEach { path ->
+                assertTrue(File(path).exists(), "File $path should exist")
+                assertTrue(File(path).isFile, "Path $path should be a file")
+            }
+        }
     }
 }


### PR DESCRIPTION
Replace `listFiles()` with `File.walk().take(1000)` to prevent scanning excessive files in directories with tens of thousands of event files. Improves performance and reduces resource usage during flush cycles.

Using `listFiles()` without bounds creates unpredictable resource usage that scales linearly with directory size. By limiting to 1000 files: 
-  Memory cost per call is max ~ 150 KB 
-  I/O cost (critical for network FS/cloud): Limiting to 1,000 stat() operations caps network round-trips at ~10-20ms, preventing the 500ms-2s delays that occur when enumerating large directories on
  NFS/EFS/cloud storage.

Threshold rationale: at 30-second flush intervals, 1K files represents ~8 hours of backlog

