### PR TITLE
Fix Windows file deletion by closing stream before removeFile

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
@@ -132,8 +132,8 @@ open class EventPipeline(
             val fileUrlList = parseFilePaths(storage.read(Storage.Constants.Events))
             for (url in fileUrlList) {
                 // upload event file
+                var shouldCleanup = true
                 storage.readAsStream(url)?.use { data ->
-                    var shouldCleanup = true
                     try {
                         val connection = httpClient.upload(apiHost)
                         connection.outputStream?.let {
@@ -150,10 +150,10 @@ open class EventPipeline(
                         analytics.reportInternalError(e)
                         shouldCleanup = handleUploadException(e, url)
                     }
+                }
 
-                    if (shouldCleanup) {
-                        storage.removeFile(url)
-                    }
+                if (shouldCleanup) {
+                    storage.removeFile(url)
                 }
             }
         }


### PR DESCRIPTION
Follow-up to #284

Move `storage.removeFile()` call outside the `use{}` block to ensure `InputStream` is fully closed before attempting file deletion. On Windows, files cannot be deleted while file handles remain open, causing silent deletion failures and infinite upload retries of the same batch files.