### PR TITLE
Align e2e-cli types with sdk-e2e-tests

### DIFF
--- a/e2e-cli/src/main/kotlin/cli/Main.kt
+++ b/e2e-cli/src/main/kotlin/cli/Main.kt
@@ -104,12 +104,17 @@ fun sendEvent(analytics: Analytics, event: JsonObject) {
         ?: throw IllegalArgumentException("Event missing 'type' field")
     val userId = event["userId"]?.jsonPrimitive?.content ?: ""
     val anonymousId = event["anonymousId"]?.jsonPrimitive?.content ?: ""
+    val messageId = event["messageId"]?.jsonPrimitive?.content
+    val timestamp = event["timestamp"]?.jsonPrimitive?.content
     val traits = event["traits"]?.jsonObject ?: emptyJsonObject
     val properties = event["properties"]?.jsonObject ?: emptyJsonObject
     val eventName = event["event"]?.jsonPrimitive?.content
     val name = event["name"]?.jsonPrimitive?.content
+    val category = event["category"]?.jsonPrimitive?.content
     val groupId = event["groupId"]?.jsonPrimitive?.content
     val previousId = event["previousId"]?.jsonPrimitive?.content
+    val context = event["context"]?.jsonObject
+    val integrations = event["integrations"]?.jsonObject
 
     when (type) {
         "identify" -> analytics.identify(userId, traits)


### PR DESCRIPTION
## Summary
- Add missing field extraction in e2e-cli: `messageId`, `timestamp`, `category`, `context`, `integrations`
- Fields are parsed from input JSON for type consistency; the Kotlin SDK API doesn't accept these as direct parameters
- Aligns the CLI's type handling with the canonical types defined in `sdk-e2e-tests/src/cli/types.ts`

## Test plan
- [ ] Verify `./gradlew :e2e-cli:jar` builds cleanly
- [ ] Run e2e tests with `./e2e-cli/run-e2e.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)