### PR TITLE
Fix blocking http calls which cannot be cancelled

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Settings.kt
@@ -6,6 +6,7 @@ import com.segment.analytics.kotlin.core.platform.plugins.logger.log
 import com.segment.analytics.kotlin.core.utilities.LenientJson
 import com.segment.analytics.kotlin.core.utilities.safeJsonObject
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.Serializable
@@ -89,7 +90,7 @@ suspend fun Analytics.checkSettings() {
 
     val settingsObj = withContext(networkIODispatcher) {
         log("Fetching settings on ${Thread.currentThread().name}")
-        return@withContext fetchSettings(writeKey, cdnHost)
+        return@withContext runInterruptible { fetchSettings(writeKey, cdnHost) }
     }
 
     settingsObj?.let {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -135,14 +136,16 @@ open class EventPipeline(
                 var shouldCleanup = true
                 storage.readAsStream(url)?.use { data ->
                     try {
-                        val connection = httpClient.upload(apiHost)
-                        connection.outputStream?.let {
-                            // Write the payloads into the OutputStream
-                            data.copyTo(connection.outputStream)
-                            connection.outputStream.close()
+                        runInterruptible {
+                            val connection = httpClient.upload(apiHost)
+                            connection.outputStream?.let {
+                                // Write the payloads into the OutputStream
+                                data.copyTo(connection.outputStream)
+                                connection.outputStream.close()
 
-                            // Upload the payloads.
-                            connection.close()
+                                // Upload the payloads.
+                                connection.close()
+                            }
                         }
                         // Cleanup uploaded payloads
                         analytics.log("$logTag uploaded $url")


### PR DESCRIPTION
The analytics-kotlin library runs blocking OkHttp calls (client.newCall(request).execute()) inside coroutines via withContext and launch, but without runInterruptible. This means Job.cancel() cannot interrupt in-flight HTTP calls the coroutine only cancels at the next suspension point, not during the blocking I/O. Wrapping in runInterruptible causes coroutine cancellation to trigger Thread.interrupt(), which OkHttp handles by aborting the connection immediately.

Signed-off-by: Olivier Lamy <olamy@apache.org>
