### PR TITLE
Fix waiting plugin force to run not scheduled

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
@@ -57,6 +57,8 @@ open class Analytics protected constructor(
             }
         }
 
+    internal var forceRunningJob: Job? = null
+
     companion object {
         var debugLogsEnabled: Boolean = false
 

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Analytics.kt
@@ -12,6 +12,7 @@ import com.segment.analytics.kotlin.core.platform.plugins.UserInfoPlugin
 import com.segment.analytics.kotlin.core.platform.plugins.logger.*
 import com.segment.analytics.kotlin.core.utilities.JsonAnySerializer
 import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.Json.Default.decodeFromJsonElement
@@ -58,6 +59,7 @@ open class Analytics protected constructor(
         }
 
     internal var forceRunningJob: Job? = null
+    internal val forceRunningMutex = Mutex()
 
     companion object {
         var debugLogsEnabled: Boolean = false

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Waiting.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Waiting.kt
@@ -44,14 +44,16 @@ internal suspend fun Analytics.running(): Boolean {
 }
 
 internal suspend fun Analytics.pauseEventProcessing(timeout: Long = 30_000) {
-    if (!running()) return
+    if (forceRunningJob?.isActive == true) return
 
     store.dispatch(System.ToggleRunningAction(false), System::class)
-    startProcessingAfterTimeout(timeout)
+    forceRunningJob = startProcessingAfterTimeout(timeout)
 }
 
 internal suspend fun Analytics.resumeEventProcessing() {
     if (running()) return
+    forceRunningJob?.cancel()
+    forceRunningJob = null
     store.dispatch(System.ToggleRunningAction(true), System::class)
 }
 

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Waiting.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Waiting.kt
@@ -3,6 +3,7 @@ package com.segment.analytics.kotlin.core
 import com.segment.analytics.kotlin.core.platform.Plugin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.withLock
 
 /**
  * An interface that provides functionality of pausing and resuming event processing on Analytics.
@@ -44,21 +45,28 @@ internal suspend fun Analytics.running(): Boolean {
 }
 
 internal suspend fun Analytics.pauseEventProcessing(timeout: Long = 30_000) {
-    if (forceRunningJob?.isActive == true) return
+    forceRunningMutex.withLock {
+        if (forceRunningJob?.isActive == true) return
 
-    store.dispatch(System.ToggleRunningAction(false), System::class)
-    forceRunningJob = startProcessingAfterTimeout(timeout)
+        store.dispatch(System.ToggleRunningAction(false), System::class)
+        forceRunningJob = startProcessingAfterTimeout(timeout)
+    }
 }
 
 internal suspend fun Analytics.resumeEventProcessing() {
     if (running()) return
-    forceRunningJob?.cancel()
-    forceRunningJob = null
+    forceRunningMutex.withLock {
+        forceRunningJob?.cancel()
+        forceRunningJob = null
+    }
     store.dispatch(System.ToggleRunningAction(true), System::class)
 }
 
 internal fun Analytics.startProcessingAfterTimeout(timeout: Long) = analyticsScope.launch(analyticsDispatcher) {
     delay(timeout)
     store.dispatch(System.ForceRunningAction(), System::class)
+    forceRunningMutex.withLock {
+        forceRunningJob = null
+    }
 }
 

--- a/core/src/main/java/com/segment/analytics/kotlin/core/Waiting.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/Waiting.kt
@@ -55,9 +55,14 @@ internal suspend fun Analytics.pauseEventProcessing(timeout: Long = 30_000) {
 
 internal suspend fun Analytics.resumeEventProcessing() {
     if (running()) return
-    forceRunningMutex.withLock {
-        forceRunningJob?.cancel()
-        forceRunningJob = null
+    // Only cancel forceRunningJob if no plugins are waiting
+    // This ensures other waiting plugins still have the safety timeout
+    val system = store.currentState(System::class)
+    if (system?.waitingPlugins?.isEmpty() == true) {
+        forceRunningMutex.withLock {
+            forceRunningJob?.cancel()
+            forceRunningJob = null
+        }
     }
     store.dispatch(System.ToggleRunningAction(true), System::class)
 }

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/WaitingTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/WaitingTests.kt
@@ -279,6 +279,20 @@ class WaitingTests {
         assertTrue(analytics.running())
     }
 
+    @Test
+    fun `test forceRunningJob is cleared after natural timeout completion`() = testScope.runTest {
+        assertTrue(analytics.running())
+        analytics.pauseEventProcessing(1000)
+        assertFalse(analytics.running())
+        assertNotNull(analytics.forceRunningJob)
+        assertTrue(analytics.forceRunningJob?.isActive == true)
+
+        // After timeout, ForceRunningAction fires and forceRunningJob should be cleared
+        advanceTimeBy(2000)
+        assertTrue(analytics.running())
+        assertNull(analytics.forceRunningJob)
+    }
+
     class ExampleWaitingPlugin: EventPlugin, WaitingPlugin {
         override val type: Plugin.Type = Plugin.Type.Enrichment
         override lateinit var analytics: Analytics

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/WaitingTests.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/WaitingTests.kt
@@ -207,6 +207,78 @@ class WaitingTests {
         assertTrue(plugin2.tracked)
     }
 
+    @Test
+    fun `test manual resume cancels pending force running job`() = testScope.runTest {
+        assertTrue(analytics.running())
+        analytics.pauseEventProcessing(10000)
+        assertFalse(analytics.running())
+        assertNotNull(analytics.forceRunningJob)
+        assertTrue(analytics.forceRunningJob?.isActive == true)
+
+        // Manual resume before timeout
+        analytics.resumeEventProcessing()
+        assertTrue(analytics.running())
+        assertNull(analytics.forceRunningJob)
+
+        // Pause again and verify no stale ForceRunningAction fires from first pause
+        analytics.pauseEventProcessing(10000)
+        assertFalse(analytics.running())
+
+        // Advance past the first timeout - should NOT resume since it was cancelled
+        advanceTimeBy(5000)
+        assertFalse(analytics.running())
+
+        // Advance past the second timeout - should resume
+        advanceTimeBy(10000)
+        assertTrue(analytics.running())
+    }
+
+    @Test
+    fun `test pause-resume-pause cycle works correctly`() = testScope.runTest {
+        assertTrue(analytics.running())
+
+        // First pause
+        analytics.pauseEventProcessing(5000)
+        assertFalse(analytics.running())
+
+        // Resume before timeout
+        advanceTimeBy(2000)
+        analytics.resumeEventProcessing()
+        assertTrue(analytics.running())
+
+        // Second pause with new timeout
+        analytics.pauseEventProcessing(5000)
+        assertFalse(analytics.running())
+
+        // Advance time - only second timeout should apply
+        advanceTimeBy(3000) // Total 5s from start, but only 3s from second pause
+        assertFalse(analytics.running()) // Should still be paused
+
+        advanceTimeBy(3000) // Now 6s from second pause
+        assertTrue(analytics.running()) // Should be running now
+    }
+
+    @Test
+    fun `test pause schedules force running even when system not running`() = testScope.runTest {
+        assertTrue(analytics.running())
+
+        // Force the system to not running state without scheduling a ForceRunningAction
+        analytics.store.dispatch(System.ToggleRunningAction(false), System::class)
+        assertFalse(analytics.running())
+        assertNull(analytics.forceRunningJob)
+
+        // Now call pauseEventProcessing - it should schedule a ForceRunningAction
+        // even though the system is already not running
+        analytics.pauseEventProcessing(1000)
+        assertFalse(analytics.running())
+        assertNotNull(analytics.forceRunningJob)
+        assertTrue(analytics.forceRunningJob?.isActive == true)
+
+        // After timeout, ForceRunningAction should fire and resume
+        advanceTimeBy(2000)
+        assertTrue(analytics.running())
+    }
+
     class ExampleWaitingPlugin: EventPlugin, WaitingPlugin {
         override val type: Plugin.Type = Plugin.Type.Enrichment
         override lateinit var analytics: Analytics


### PR DESCRIPTION
the problem:
previously [pauseEventProcessing](http://github.com/segmentio/analytics-kotlin/blob/main/core/src/main/java/com/segment/analytics/kotlin/core/Waiting.kt#L47) returns immediately if the sdk is not in running state to avoid schedule multiple ForceRunningAction. but there is a race condition. following are the sequence of problematic order:
  1. Analytics instance is created
    - System state: running = false (initial state in System.defaultState())
    - waitingPlugins = emptySet()
  2. WaitingPlugin is added via analytics.add(waitingPlugin)
    - WaitingPlugin.setup() is called
    - setup() calls pause()
    - pause() calls analytics.pauseEventProcessing(this)
  3. [pauseEventProcessing(plugin)](https://github.com/segmentio/analytics-kotlin/blob/main/core/src/main/java/com/segment/analytics/kotlin/core/Waiting.kt#L31) executes:
  store.dispatch(System.AddWaitingPlugin(plugin.hashCode()), System::class)
  // waitingPlugins now contains the plugin
  pauseEventProcessing()  // calls the internal function
  4. Internal [pauseEventProcessing()](https://github.com/segmentio/analytics-kotlin/blob/main/core/src/main/java/com/segment/analytics/kotlin/core/Waiting.kt#L54) executes:
  if (!running()) return  // running() is FALSE (system not started yet)
                          // → RETURNS EARLY! 
  // These lines NEVER execute:
  // store.dispatch(System.ToggleRunningAction(false), System::class)
  // startProcessingAfterTimeout(timeout)  ← ForceRunningAction NOT scheduled!
  5. Later, system starts (settings received)
    - System tries to set running = true via ToggleRunningAction(true)
    - But reducer checks: if (running && state.waitingPlugins.isNotEmpty()) { running = false }
    - Since waitingPlugins is NOT empty, running stays false
  6. System is now stuck forever:
    - running = false
    - waitingPlugins contains the plugin
    - No ForceRunningAction is scheduled to force-resume after timeout
    - If the WaitingPlugin never calls resume(), the pipeline is blocked indefinitely

this pr fixed this issue by checking if a ForceRunningAction is already scheduled (via forceRunningJob?.isActive) instead of checking running(), so we always schedule the timeout even when the system hasn't started yet.

