### PR TITLE
feat: CDN httpConfig support for retry-settings tests

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
@@ -42,8 +42,8 @@ open class EventPipeline(
 
     protected open val networkIODispatcher get() = analytics.networkIODispatcher
 
-    // Retry state machine for smart retry logic 
-    private val retryStateMachine: RetryStateMachine
+    // Retry state machine for smart retry logic
+    private var retryStateMachine: RetryStateMachine
     private var retryState: RetryState
 
 
@@ -111,6 +111,18 @@ open class EventPipeline(
         uploadChannel.cancel()
         writeChannel.cancel()
         unschedule()
+    }
+
+    /**
+     * Update the retry configuration from CDN settings.
+     * Recreates the RetryStateMachine with the new config while preserving retry state.
+     */
+    fun updateHttpConfig(newConfig: HttpConfig) {
+        val retryConfig = RetryConfig(
+            rateLimitConfig = newConfig.rateLimitConfig,
+            backoffConfig = newConfig.backoffConfig
+        )
+        retryStateMachine = RetryStateMachine(retryConfig, timeProvider)
     }
 
     open fun stringifyBaseEvent(payload: BaseEvent): String {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/SegmentDestination.kt
@@ -11,6 +11,9 @@ import com.segment.analytics.kotlin.core.platform.policies.FrequencyFlushPolicy
 import com.segment.analytics.kotlin.core.retry.HttpConfig
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import sovran.kotlin.Subscriber
 
 @Serializable
@@ -103,9 +106,32 @@ class SegmentDestination: DestinationPlugin(), VersionedPlugin, Subscriber {
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         super.update(settings, type)
         if (settings.hasIntegrationSettings(this)) {
-            // only populate the apiHost value if it exists
-            settings.destinationSettings<SegmentSettings>(key)?.apiHost?.let {
+            val segmentSettings = settings.destinationSettings<SegmentSettings>(key)
+
+            // Update apiHost if it exists
+            segmentSettings?.apiHost?.let {
                 pipeline?.apiHost = it
+            }
+
+            // Read httpConfig from CDN settings and apply to pipeline
+            segmentSettings?.httpConfig?.let { cdnConfig ->
+                // CDN-sourced config defaults enabled to true (presence implies active).
+                // Only honor explicit enabled: false from CDN.
+                val rawJson = settings.integrations[key]?.jsonObject
+                val httpConfigJson = rawJson?.get("httpConfig")?.jsonObject
+
+                val rlEnabled = httpConfigJson?.get("rateLimitConfig")?.jsonObject
+                    ?.get("enabled")?.jsonPrimitive?.booleanOrNull
+                val boEnabled = httpConfigJson?.get("backoffConfig")?.jsonObject
+                    ?.get("enabled")?.jsonPrimitive?.booleanOrNull
+
+                val adjustedConfig = HttpConfig(
+                    rateLimitConfig = cdnConfig.rateLimitConfig.copy(enabled = rlEnabled ?: true),
+                    backoffConfig = cdnConfig.backoffConfig.copy(enabled = boEnabled ?: true)
+                )
+
+                analytics.configuration.httpConfig = adjustedConfig
+                pipeline?.updateHttpConfig(adjustedConfig)
             }
         }
     }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/retry/RetryStateMachine.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/retry/RetryStateMachine.kt
@@ -36,14 +36,20 @@ class RetryStateMachine(
                 )
             }
 
-            response.statusCode == 429 && config.rateLimitConfig.enabled -> {
-                handleRateLimitResponse(state, response, currentTime)
+            response.statusCode == 429 -> {
+                if (config.rateLimitConfig.enabled) {
+                    handleRateLimitResponse(state, response, currentTime)
+                } else {
+                    // Rate limit handling disabled: drop (don't fall through to backoff)
+                    state.removeBatch(response.batchFile)
+                }
             }
 
             behavior == RetryBehavior.RETRY && config.backoffConfig.enabled -> {
                 handleRetryableError(state, response, currentTime)
             }
 
+            // Drop non-retryable errors, or retryable errors when backoff is disabled
             else -> {
                 state.removeBatch(response.batchFile)
             }
@@ -132,7 +138,14 @@ class RetryStateMachine(
             state
         }
 
-        // Check 2: Per-batch metadata
+        // Check 2: Global rate limit retry count
+        if (config.rateLimitConfig.enabled &&
+            clearedState.globalRetryCount >= config.rateLimitConfig.maxRetryCount) {
+            return UploadDecision.DropBatch(DropReason.MAX_RETRIES_EXCEEDED) to
+                   clearedState.copy(globalRetryCount = 0).removeBatch(batchFile)
+        }
+
+        // Check 3: Per-batch metadata
         val metadata = clearedState.batchMetadata[batchFile]
         if (metadata != null) {
             // Check retry count limit (must be checked before duration per spec)
@@ -173,8 +186,12 @@ class RetryStateMachine(
             return statusCode in 400..499 && statusCode != 429
         }
         if (statusCode in 200..299) return true // Success: file can be removed
-        if (statusCode == 429 && config.rateLimitConfig.enabled) return false
-        return resolveStatusCodeBehavior(statusCode) == RetryBehavior.DROP
+        // 429 with rate limit handling disabled: delete
+        if (statusCode == 429) return !config.rateLimitConfig.enabled
+        val behavior = resolveStatusCodeBehavior(statusCode)
+        // Retryable error with backoff disabled: delete
+        if (behavior == RetryBehavior.RETRY && !config.backoffConfig.enabled) return true
+        return behavior == RetryBehavior.DROP
     }
 
     private fun resolveStatusCodeBehavior(code: Int): RetryBehavior {

--- a/core/src/main/java/com/segment/analytics/kotlin/core/retry/RetryTypes.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/retry/RetryTypes.kt
@@ -1,5 +1,6 @@
 package com.segment.analytics.kotlin.core.retry
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -10,8 +11,8 @@ enum class PipelineState {
 
 @Serializable
 enum class RetryBehavior {
-    RETRY,
-    DROP
+    @SerialName("retry") RETRY,
+    @SerialName("drop") DROP
 }
 
 @Serializable

--- a/e2e-cli/e2e-config.json
+++ b/e2e-cli/e2e-config.json
@@ -1,7 +1,9 @@
 {
   "sdk": "kotlin",
-  "test_suites": "basic,settings,retry",
+  "test_suites": "basic,settings,retry,retry-settings",
   "auto_settings": true,
   "patch": "analytics-kotlin-http.patch",
-  "env": {}
+  "env": {
+    "HTTP_CONFIG_SETTINGS": "true"
+  }
 }


### PR DESCRIPTION
## Summary
- Read `httpConfig` from CDN integration settings in `SegmentDestination.update()` and propagate to `EventPipeline` via `updateHttpConfig()`
- Default `enabled` to `true` for CDN-sourced configs (presence of httpConfig implies active)
- Add `@SerialName` annotations to `RetryBehavior` enum for lowercase JSON compatibility (`"retry"`/`"drop"` from CDN)
- Enforce `rateLimitConfig.maxRetryCount` via `globalRetryCount` in `RetryStateMachine.shouldUploadBatch()`
- Add `retry-settings` test suite to `e2e-config.json`

## Test plan
- [x] All 20 retry-settings e2e tests pass (backoff-settings, rate-limit-settings, partial-config, settings-enabled-flag)
- [x] All 59 existing e2e tests pass (basic, retry, settings) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)