### PR TITLE
fix: use analyticsDispatcher for StartupQueue state subscription

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/StartupQueue.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/plugins/StartupQueue.kt
@@ -32,6 +32,7 @@ class StartupQueue : Plugin, Subscriber {
                     subscriber = this@StartupQueue,
                     stateClazz = System::class,
                     initialState = true,
+                    queue = analyticsDispatcher,
                     handler = this@StartupQueue::runningUpdate
                 )
             }


### PR DESCRIPTION
## Summary
- StartupQueue subscribes to Sovran store state changes without specifying a `queue` parameter, defaulting to `Dispatchers.Default`
- When the store notifies subscribers of a running-state change (e.g. after a WaitingPlugin resumes), the handler (`runningUpdate` → `replayEvents` → `analytics.process`) executes on a real thread pool rather than the analytics dispatcher
- This causes a race condition in CI where WaitingTests fail intermittently — the event replay hasn't completed by the time assertions run
- Fix: pass `analyticsDispatcher` as the `queue` parameter so notification handlers run on the same dispatcher as the rest of the analytics pipeline

## Root cause
Sovran store's `notify` method launches subscriber handlers via `sovranScope.launch(sub.queue)` fire-and-forget. The default queue is `Dispatchers.Default`, which bypasses the test's `UnconfinedTestDispatcher`. Under CI resource contention, the handler coroutine loses the race against test assertions.

## Test plan
- [x] `WaitingTests` pass locally (all 9 tests)
- [x] Full `:core:test` suite passes
- [ ] CI `core-test` job passes (previously failing `test WaitingPlugin makes analytics to wait` and `test timeout force resume on DestinationPlugin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)