### PR TITLE
ci: publish e2e-cli build to sdk-e2e-tests on merge

### DIFF
--- a/.github/workflows/publish-e2e-cli.yml
+++ b/.github/workflows/publish-e2e-cli.yml
@@ -1,0 +1,64 @@
+# Publish E2E CLI build to sdk-e2e-tests cli-builds branch
+#
+# On merge to main, builds the e2e-cli fat JAR and pushes it
+# to the cli-builds branch of sdk-e2e-tests.
+
+name: Publish E2E CLI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'e2e-cli/**'
+      - 'core/src/**'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout SDK
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Build e2e-cli
+        run: ./gradlew :e2e-cli:jar
+
+      - name: Find e2e-cli jar
+        id: find-jar
+        run: |
+          JAR_PATH=$(find e2e-cli/build/libs -name "e2e-cli-*.jar" | head -1)
+          echo "jar_path=$JAR_PATH" >> $GITHUB_OUTPUT
+
+      - name: Checkout sdk-e2e-tests (cli-builds branch)
+        uses: actions/checkout@v4
+        with:
+          repository: segmentio/sdk-e2e-tests
+          ref: cli-builds
+          token: ${{ secrets.E2E_TESTS_TOKEN }}
+          path: sdk-e2e-tests-builds
+          fetch-depth: 1
+
+      - name: Copy CLI artifact
+        run: |
+          rm -rf sdk-e2e-tests-builds/analytics-kotlin
+          mkdir -p sdk-e2e-tests-builds/analytics-kotlin
+          cp ${{ steps.find-jar.outputs.jar_path }} sdk-e2e-tests-builds/analytics-kotlin/e2e-cli.jar
+
+      - name: Push to cli-builds branch
+        working-directory: sdk-e2e-tests-builds
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to CLI build"
+          else
+            git commit -m "update analytics-kotlin CLI build (${GITHUB_SHA::8})"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- Adds a workflow that builds the e2e-cli fat JAR on merge to main and pushes it to the `cli-builds` branch of sdk-e2e-tests
- Only triggers when `e2e-cli/` or `core/src/` paths change
- Uses existing `E2E_TESTS_TOKEN` secret for cross-repo push

## Test plan
- [ ] Verify `E2E_TESTS_TOKEN` has write access to sdk-e2e-tests
- [ ] Merge and confirm artifact appears at `sdk-e2e-tests@cli-builds:analytics-kotlin/e2e-cli.jar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)