### PR TITLE
docs: fix stale release, contributing, and Java-compat instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ To get started with the project
 - clone this repository
 - import the project into Android Studio
 
-While developing, you can run the [example app](/example/) to test your changes.
+While developing, you can run one of the [example apps](/samples/) to test your changes.
 - You can do this via the IDE itself using the `Run app` button in the toolbar
-- You can install the debug version of the app using the gradle command:
+- You can install the debug version of an app using the gradle command (targeting a specific sample module):
 ```
-./gradlew installDebug
+./gradlew :samples:kotlin-android-app:installDebug
 ```
 
 Remember to add tests for your change if possible. Run the unit tests:
@@ -30,9 +30,9 @@ We follow the [conventional commits specification](https://www.conventionalcommi
 
 - `fix`: bug fixes, e.g. fix crash due to deprecated method.
 - `feat`: new features, e.g. add new method to the module.
-- `refactor`: code refactor, e.g. migrate from class components to hooks.
-- `docs`: changes into documentation, e.g. add usage example for the module..
-- `test`: adding or updating tests, eg add integration tests using detox.
+- `refactor`: code refactor, e.g. extract a helper or restructure a plugin.
+- `docs`: changes into documentation, e.g. add usage example for the module.
+- `test`: adding or updating tests, e.g. add unit tests for a new plugin.
 - `chore`: tooling changes, e.g. change CI config.
 
 ### Linting and tests

--- a/JAVA_COMPAT.md
+++ b/JAVA_COMPAT.md
@@ -1,11 +1,7 @@
 # Analytics-Kotlin Java Compatibility 
-[![](https://jitpack.io/v/segmentio/analytics-kotlin.svg)](https://jitpack.io/#segmentio/analytics-kotlin)
+[![maven](https://img.shields.io/maven-central/v/com.segment.analytics.kotlin/android)](https://repo1.maven.org/maven2/com/segment/analytics/kotlin/)
 
 The hassle-free way to add Segment analytics to your kotlin app (Android/JVM).
-
-NOTE: This project is currently in the Pilot phase and is covered by Segment's [First Access & Beta Preview Terms](https://segment.com/legal/first-access-beta-preview/).  We encourage you
-to try out this new library. Please provide feedback via Github issues/PRs, and feel free to submit pull requests.  This library will eventually 
-supplant our `analytics-android` library.
 
 NOTE: This document serves as an explanation of usage of this `analytics-kotlin` library for pure Java codebase. For the sample usages in Kotlin and more detailed architectural explanation, please refer to our main [README.md doc](README.md).
 
@@ -35,7 +31,7 @@ NOTE: This document serves as an explanation of usage of this `analytics-kotlin`
   - [License](#license)
 
 ## Installation
-For our pilot phase, we will be using [jitpack](https://jitpack.io/#segmentio/analytics-kotlin) to distribute the library
+The library is published to Maven Central under the `com.segment.analytics.kotlin` group.
 <details open>
 <summary>Android</summary>
 <br>
@@ -43,11 +39,11 @@ In your app's build.gradle file add the following
 
 ```groovy
 repositories {
-    maven { url 'https://jitpack.io' }
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'com.github.segmentio.analytics-kotlin:android:+'
+    implementation 'com.segment.analytics.kotlin:android:1.25.0'
 }
 ```
 
@@ -60,11 +56,11 @@ dependencies {
 In your app's build.gradle file add the following
 ```groovy
 repositories {
-    maven { url 'https://jitpack.io' }
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'com.github.segmentio.analytics-kotlin:core:+'
+    implementation 'com.segment.analytics.kotlin:core:1.25.0'
 }
 ```
 </details>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ Releasing
 6. Upgrade to next version by changing version in `gradle.properties`
 7. `git commit -am "Prepare snapshot X.Y.Z-SNAPSHOT"`
 8. `git push && git push --tags`
-9. Create a PR to merge the new branch into `master`
+9. Create a PR to merge the new branch into `main`
 10. The CI pipeline will recognize the tag and upload, close and promote the artifacts automatically, and generate changelog automatically
 
 Example (stable release)
@@ -30,4 +30,4 @@ Example (stable release)
 7. Change VERSION_NAME = 1.3.2 (next higher version)
 8. `git commit -am "Prepare snapshot 1.3.2-SNAPSHOT"`
 9. `git push && git push --tags`
-10. Merging PR master will create a snapshot release 1.3.2-SNAPSHOT and tag push will create stable release 1.3.1
+10. Merging the PR into `main` will create a snapshot release 1.3.2-SNAPSHOT and the tag push will create stable release 1.3.1


### PR DESCRIPTION
## Summary

Fixes stale release/build/install documentation. Each fix was verified against the actual repo state on `main` (default branch, `.github/workflows/`, `gradle.properties`, `settings.gradle`, and `README.md`) before editing.

### `RELEASING.md`
- The repo's default branch is **`main`**, and the snapshot publish workflow (`snapshot.yml`) only triggers on push to `main`. The doc told maintainers to open a PR against / merge into `master`, which does not exist. Updated steps 9 and 10.

### `CONTRIBUTING.md`
- The example/sample apps live under **`samples/`** (`samples/kotlin-android-app`, etc., per `settings.gradle`), not the dead `/example/` link. A bare `./gradlew installDebug` doesn't resolve at the root either — it must target a sample module. Updated to `./gradlew :samples:kotlin-android-app:installDebug`.
- Replaced the React-Native-template commit-message examples ("migrate from class components to hooks", "integration tests using detox") with Kotlin-relevant ones — neither React hooks nor Detox exist in this repo.

### `JAVA_COMPAT.md`
- The library is published to **Maven Central** under `com.segment.analytics.kotlin` (current `VERSION_NAME` is `1.25.0`), as the README badge already reflects. The Java-compat install instructions still pointed at a jitpack "pilot phase" distribution with the non-resolving coordinate `com.github.segmentio.analytics-kotlin`. Replaced the jitpack badge, repository, and coordinates with Maven Central, and removed the stale "Pilot phase / First Access & Beta Preview" notice (the library is GA).

## Validation
- All replacement paths, coordinates, branch names, and the version were confirmed against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
