### PR TITLE
feat: honor Retry-After header on any retryable HTTP response

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/platform/EventPipeline.kt
@@ -267,8 +267,21 @@ open class EventPipeline(
                     batchFile = url,
                     currentTime = timeProvider.currentTimeMillis()
                 )
+                val previousState = retryState
                 retryState = retryStateMachine.handleResponse(retryState, responseInfo)
-                
+
+                // Log when Retry-After triggers a new pipeline pause
+                if (responseInfo.retryAfterSeconds != null &&
+                    previousState.pipelineState != PipelineState.RATE_LIMITED &&
+                    retryState.pipelineState == PipelineState.RATE_LIMITED) {
+                    val waitSeconds = responseInfo.retryAfterSeconds
+                    val waitUntilMs = retryState.waitUntilTime ?: 0L
+                    Analytics.segmentLog(
+                        message = "Retry-After (${waitSeconds}s) received on HTTP ${responseInfo.statusCode} — pausing pipeline until ${java.util.Date(waitUntilMs)}",
+                        kind = LogKind.WARNING
+                    )
+                }
+
                 // Persist updated retry state
                 withContext(fileIODispatcher) {
                     storage.saveRetryState(retryState)

--- a/core/src/main/java/com/segment/analytics/kotlin/core/retry/RetryStateMachine.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/retry/RetryStateMachine.kt
@@ -45,11 +45,19 @@ class RetryStateMachine(
                 }
             }
 
-            behavior == RetryBehavior.RETRY && config.backoffConfig.enabled -> {
-                handleRetryableError(state, response, currentTime)
+            behavior == RetryBehavior.RETRY -> {
+                when {
+                    response.retryAfterSeconds != null && config.rateLimitConfig.enabled -> {
+                        handleRateLimitResponse(state, response, currentTime)
+                    }
+                    config.backoffConfig.enabled -> {
+                        handleRetryableError(state, response, currentTime)
+                    }
+                    else -> state.removeBatch(response.batchFile)
+                }
             }
 
-            // Drop non-retryable errors, or retryable errors when backoff is disabled
+            // Drop non-retryable errors
             else -> {
                 state.removeBatch(response.batchFile)
             }

--- a/core/src/main/java/com/segment/analytics/kotlin/core/retry/RetryStateMachine.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/retry/RetryStateMachine.kt
@@ -197,8 +197,11 @@ class RetryStateMachine(
         // 429 with rate limit handling disabled: delete
         if (statusCode == 429) return !config.rateLimitConfig.enabled
         val behavior = resolveStatusCodeBehavior(statusCode)
-        // Retryable error with backoff disabled: delete
-        if (behavior == RetryBehavior.RETRY && !config.backoffConfig.enabled) return true
+        if (behavior == RetryBehavior.RETRY) {
+            if (config.rateLimitConfig.enabled) return false  // rate-limit path handles it
+            if (!config.backoffConfig.enabled) return true    // no retry mechanism: delete
+            return false
+        }
         return behavior == RetryBehavior.DROP
     }
 

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/retry/RetryAfterGenericTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/retry/RetryAfterGenericTest.kt
@@ -1,0 +1,163 @@
+package com.segment.analytics.kotlin.core.retry
+
+import com.segment.analytics.kotlin.core.retry.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class RetryAfterGenericTest {
+
+    private fun makeConfig(maxRetryCount: Int = 100): RetryConfig = RetryConfig(
+        rateLimitConfig = RateLimitConfig(
+            enabled = true,
+            maxRetryCount = maxRetryCount,
+            maxRetryInterval = 300
+        ),
+        backoffConfig = BackoffConfig(
+            enabled = true,
+            baseBackoffInterval = 0.5,
+            maxBackoffInterval = 300,
+            maxTotalBackoffDuration = 43200,
+            jitterPercent = 0
+        )
+    )
+
+    private fun makeResponse(
+        statusCode: Int,
+        batchFile: String = "batch1",
+        retryAfterSeconds: Int? = null,
+        currentTime: Long = 1_000_000L
+    ) = ResponseInfo(
+        statusCode = statusCode,
+        batchFile = batchFile,
+        retryAfterSeconds = retryAfterSeconds,
+        currentTime = currentTime
+    )
+
+    @Test
+    fun `529 with Retry-After triggers pipeline-level pause`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(529, retryAfterSeconds = 30, currentTime = 1_000_000L))
+
+        assertEquals(PipelineState.RATE_LIMITED, newState.pipelineState)
+        assertEquals(1_030_000L, newState.waitUntilTime)
+        assertEquals(1, newState.globalRetryCount)
+        assertNull(newState.batchMetadata["batch1"])
+    }
+
+    @Test
+    fun `529 with Retry-After does not increment failureCount`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(529, retryAfterSeconds = 30))
+        assertNull(newState.batchMetadata["batch1"])
+    }
+
+    @Test
+    fun `503 with Retry-After triggers pipeline-level pause`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(503, retryAfterSeconds = 60, currentTime = 1_000_000L))
+
+        assertEquals(PipelineState.RATE_LIMITED, newState.pipelineState)
+        assertEquals(1_060_000L, newState.waitUntilTime)
+        assertEquals(1, newState.globalRetryCount)
+    }
+
+    @Test
+    fun `408 with Retry-After triggers pipeline-level pause`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(408, retryAfterSeconds = 10, currentTime = 1_000_000L))
+
+        assertEquals(PipelineState.RATE_LIMITED, newState.pipelineState)
+        assertEquals(1_010_000L, newState.waitUntilTime)
+    }
+
+    @Test
+    fun `529 without Retry-After uses exponential backoff`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(529, retryAfterSeconds = null))
+
+        assertEquals(PipelineState.READY, newState.pipelineState)
+        assertNull(newState.waitUntilTime)
+        assertEquals(0, newState.globalRetryCount)
+        assertNotNull(newState.batchMetadata["batch1"])
+        assertEquals(1, newState.batchMetadata["batch1"]?.failureCount)
+    }
+
+    @Test
+    fun `503 without Retry-After uses exponential backoff`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(503, retryAfterSeconds = null))
+
+        assertEquals(PipelineState.READY, newState.pipelineState)
+        assertNotNull(newState.batchMetadata["batch1"])
+    }
+
+    @Test
+    fun `Retry-After clamped at maxRetryInterval`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(529, retryAfterSeconds = 99999, currentTime = 1_000_000L))
+        assertEquals(1_300_000L, newState.waitUntilTime)
+    }
+
+    @Test
+    fun `Retry-After zero sets waitUntilTime to now`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(529, retryAfterSeconds = 0, currentTime = 1_000_000L))
+
+        assertEquals(PipelineState.RATE_LIMITED, newState.pipelineState)
+        assertEquals(1_000_000L, newState.waitUntilTime)
+    }
+
+    @Test
+    fun `globalRetryCount cap drops batch after maxRetryCount`() {
+        val config = makeConfig(maxRetryCount = 3)
+        val machine = RetryStateMachine(config)
+
+        var state = RetryState()
+        for (i in 1..3) {
+            state = machine.handleResponse(state, makeResponse(529, retryAfterSeconds = 1, currentTime = i * 100_000L))
+        }
+        assertEquals(3, state.globalRetryCount)
+
+        val timeProvider = FakeTimeProvider(currentTime = 10_000_000L)
+        val dropMachine = RetryStateMachine(config, timeProvider)
+        val (decision, _) = dropMachine.shouldUploadBatch(state, "batch1")
+        assertEquals(UploadDecision.DropBatch(DropReason.MAX_RETRIES_EXCEEDED), decision)
+    }
+
+    @Test
+    fun `400 with Retry-After drops immediately`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(400, retryAfterSeconds = 60))
+
+        assertEquals(PipelineState.READY, newState.pipelineState)
+        assertNull(newState.batchMetadata["batch1"])
+        assertNull(newState.waitUntilTime)
+        assertEquals(0, newState.globalRetryCount)
+    }
+
+    @Test
+    fun `429 behavior unchanged`() {
+        val machine = RetryStateMachine(makeConfig())
+        val newState = machine.handleResponse(RetryState(), makeResponse(429, retryAfterSeconds = 45, currentTime = 1_000_000L))
+
+        assertEquals(PipelineState.RATE_LIMITED, newState.pipelineState)
+        assertEquals(1_045_000L, newState.waitUntilTime)
+        assertEquals(1, newState.globalRetryCount)
+        assertNull(newState.batchMetadata["batch1"])
+    }
+
+    @Test
+    fun `pipeline pause holds all batches`() {
+        val config = makeConfig()
+        val timeProvider = FakeTimeProvider(currentTime = 1_000_000L)
+        val machine = RetryStateMachine(config, timeProvider)
+
+        val pausedState = machine.handleResponse(RetryState(), makeResponse(529, retryAfterSeconds = 30, currentTime = 1_000_000L))
+
+        val (decision1, _) = machine.shouldUploadBatch(pausedState, "batch1")
+        val (decision2, _) = machine.shouldUploadBatch(pausedState, "batch2")
+
+        assertEquals(UploadDecision.SkipAllBatches, decision1)
+        assertEquals(UploadDecision.SkipAllBatches, decision2)
+    }
+}

--- a/core/src/test/kotlin/com/segment/analytics/kotlin/core/retry/RetryAfterGenericTest.kt
+++ b/core/src/test/kotlin/com/segment/analytics/kotlin/core/retry/RetryAfterGenericTest.kt
@@ -147,6 +147,17 @@ class RetryAfterGenericTest {
     }
 
     @Test
+    fun `shouldDeleteBatch returns false for retryable code when rateLimitConfig enabled`() {
+        val config = RetryConfig(
+            rateLimitConfig = RateLimitConfig(enabled = true),
+            backoffConfig = BackoffConfig(enabled = false)
+        )
+        val machine = RetryStateMachine(config)
+        assertFalse(machine.shouldDeleteBatch(503))
+        assertFalse(machine.shouldDeleteBatch(529))
+    }
+
+    @Test
     fun `pipeline pause holds all batches`() {
         val config = makeConfig()
         val timeProvider = FakeTimeProvider(currentTime = 1_000_000L)


### PR DESCRIPTION
## Summary
- Any retryable HTTP response carrying a `Retry-After` header now triggers a pipeline-level pause, identical to 429 behavior
- Codes without `Retry-After` continue to use existing exponential backoff unchanged
- Emits a warning log when `Retry-After` triggers a new pipeline pause (any code including 429)
- Fixes `shouldDeleteBatch()` bug: retryable batches were incorrectly deleted when `rateLimitConfig.enabled=true, backoffConfig.enabled=false`
- Existing 429 behavior is unchanged

## Motivation
Per RFC 9110, `Retry-After` is a general-purpose header. Previously the SDK only respected it for 429; a 529 (or 503) with `Retry-After` would be silently ignored and the SDK would compute its own (potentially shorter) backoff, increasing load on an already-overloaded server.

## Test plan
- [ ] `RetryAfterGenericTest` — all 13 new tests pass
- [ ] Full Gradle test suite passes with no regressions in retry tests
- [ ] Manual: connect to test endpoint returning 529 + `Retry-After: 5`, observe pipeline pause in logs