### PR TITLE
fix: use in-memory PGP signing instead of writing key to tmp file

### DIFF
--- a/gradle/promote.gradle
+++ b/gradle/promote.gradle
@@ -9,15 +9,7 @@ if (!hasProperty("signing.keyId")) {
 
     def pgpKeyContent = System.getenv('SIGNING_PRIVATE_KEY_BASE64')
     if (pgpKeyContent != null) {
-        def tmpDir = new File("$rootProject.rootDir/tmp")
-        mkdir tmpDir
-        def keyFile = new File("$tmpDir/key.pgp")
-        keyFile.createNewFile()
-        def os = keyFile.newDataOutputStream()
-        os.write(pgpKeyContent.decodeBase64())
-        os.close()
-
-        ext['signing.secretKeyRingFile'] = keyFile.absolutePath
+        ext['signing.key'] = new String(pgpKeyContent.decodeBase64())
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces the approach of writing the base64-decoded PGP key to a tmp file (`tmp/key.pgp`) with setting it as an in-memory string property (`signing.key`)
- `mvn-publish.gradle` already uses `useInMemoryPgpKeys()` which reads from `signing.key` — the old file-based approach was incompatible with it
- Removes the tmp directory creation side effect during builds

## Test plan
- [ ] Verified working end-to-end: the 1.26.0 release was published to Maven Central successfully with this change in place