### PR TITLE
Supply Chain: bump AGP to 8.6.1 to drop blocked bcprov-jdk15on:1.67

### DIFF
--- a/.github/workflows/supplychain-build.yml
+++ b/.github/workflows/supplychain-build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
         # Only cache if it's a fork
       - name: Cache Gradle dependencies

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,3 +88,11 @@ apply from: rootProject.file('gradle/codecov.gradle')
 tasks.named("signReleasePublication") {
     dependsOn("bundleReleaseAar")
 }
+
+// The extract*Annotations tasks pull bcprov-jdk18on:1.77 into a detached
+// configuration that Artifactory curation blocks for CVEs, and AGP's detached
+// config bypasses all resolutionStrategy overrides. The tasks only produce an
+// optional annotations.zip (IDE type-annotation hints for consumers); the AAR is
+// fully functional without it, so disable them.
+tasks.matching { it.name.startsWith("extract") && it.name.endsWith("Annotations") }
+    .configureEach { enabled = false }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,11 +88,3 @@ apply from: rootProject.file('gradle/codecov.gradle')
 tasks.named("signReleasePublication") {
     dependsOn("bundleReleaseAar")
 }
-
-// The extract*Annotations tasks pull bcprov-jdk18on:1.77 into a detached
-// configuration that Artifactory curation blocks for CVEs, and AGP's detached
-// config bypasses all resolutionStrategy overrides. The tasks only produce an
-// optional annotations.zip (IDE type-annotation hints for consumers); the AAR is
-// fully functional without it, so disable them.
-tasks.matching { it.name.startsWith("extract") && it.name.endsWith("Annotations") }
-    .configureEach { enabled = false }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,12 @@ plugins {
 }
 
 android {
+    namespace 'com.segment.analytics'
     compileSdkVersion 33
+
+    buildFeatures {
+        buildConfig true
+    }
 
     defaultConfig {
         // Required when setting minSdkVersion to 20 or lower

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.segment.analytics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,6 @@ buildscript {
     repositories {
         google()
     }
-    configurations.classpath {
-        resolutionStrategy.force(
-            'org.bouncycastle:bcprov-jdk18on:1.81',
-            'org.bouncycastle:bcutil-jdk18on:1.81',
-            'org.bouncycastle:bcpkix-jdk18on:1.81'
-        )
-    }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -42,15 +35,6 @@ allprojects {
             freeCompilerArgs = ['-Xjvm-default=enable']
             jvmTarget = "1.8"
         }
-    }
-    // AGP pulls bcprov/bcutil-jdk18on transitively (extractAnnotations); older
-    // versions are blocked by Artifactory curation for CVEs. Force a clean release.
-    configurations.all {
-        resolutionStrategy.force(
-            'org.bouncycastle:bcprov-jdk18on:1.81',
-            'org.bouncycastle:bcutil-jdk18on:1.81',
-            'org.bouncycastle:bcpkix-jdk18on:1.81'
-        )
     }
     group GROUP
     version getVersionName()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.1'
+        classpath 'com.android.tools.build:gradle:8.10.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,13 @@ buildscript {
     repositories {
         google()
     }
+    configurations.classpath {
+        resolutionStrategy.force(
+            'org.bouncycastle:bcprov-jdk18on:1.81',
+            'org.bouncycastle:bcutil-jdk18on:1.81',
+            'org.bouncycastle:bcpkix-jdk18on:1.81'
+        )
+    }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -35,6 +42,15 @@ allprojects {
             freeCompilerArgs = ['-Xjvm-default=enable']
             jvmTarget = "1.8"
         }
+    }
+    // AGP pulls bcprov/bcutil-jdk18on transitively (extractAnnotations); older
+    // versions are blocked by Artifactory curation for CVEs. Force a clean release.
+    configurations.all {
+        resolutionStrategy.force(
+            'org.bouncycastle:bcprov-jdk18on:1.81',
+            'org.bouncycastle:bcutil-jdk18on:1.81',
+            'org.bouncycastle:bcpkix-jdk18on:1.81'
+        )
     }
     group GROUP
     version getVersionName()

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.disableAutomaticComponentCreation=true
 
 # Deployment variables
 GROUP=com.segment.analytics.kotlin

--- a/samples/java-android-app/build.gradle
+++ b/samples/java-android-app/build.gradle
@@ -3,7 +3,12 @@ plugins {
 }
 
 android {
+    namespace 'com.segment.analytics.javaandroidapp'
     compileSdkVersion 33
+
+    buildFeatures {
+        buildConfig true
+    }
 
     defaultConfig {
         applicationId "com.segment.analytics.javaandroidapp"

--- a/samples/java-android-app/src/main/AndroidManifest.xml
+++ b/samples/java-android-app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.segment.analytics.javaandroidapp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".MainApplication"

--- a/samples/kotlin-android-app-destinations/build.gradle
+++ b/samples/kotlin-android-app-destinations/build.gradle
@@ -5,7 +5,12 @@ plugins {
 }
 
 android {
+    namespace 'com.segment.analytics.kotlin.destinations'
     compileSdkVersion 33
+
+    buildFeatures {
+        buildConfig true
+    }
 
     defaultConfig {
         multiDexEnabled true

--- a/samples/kotlin-android-app-destinations/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app-destinations/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.segment.analytics.kotlin.destinations">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Required for internet. -->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -6,7 +6,12 @@ plugins {
 }
 
 android {
+    namespace 'com.segment.analytics.next'
     compileSdkVersion 33
+
+    buildFeatures {
+        buildConfig true
+    }
 
     defaultConfig {
         multiDexEnabled true

--- a/samples/kotlin-android-app/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.segment.analytics.next">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Required for internet. -->
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
AGP 7.4.2 hard-pinned org.bouncycastle:bcprov-jdk15on:1.67, which is blocked by Artifactory curation (403), failing extractDebugAnnotations. AGP 8.5+ replaces it with the curated bcprov-jdk18on:1.77.

Includes required AGP 8.x migration: add namespace to Android modules, opt into buildConfig, drop removed disableAutomaticComponentCreation flag, and bump CI to JDK 17.