### PR TITLE
fix: read the settings response message before disconnecting

### DIFF
--- a/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
+++ b/core/src/main/java/com/segment/analytics/kotlin/core/HTTPClient.kt
@@ -157,8 +157,11 @@ open class RequestFactory(
         connection.setRequestProperty("Content-Type", "application/json; charset=utf-8")
         val responseCode = connection.responseCode
         if (responseCode != HttpURLConnection.HTTP_OK) {
+            // Read the message before disconnecting: on OkHttpURLConnection, disconnect() clears the response
+            // and a later getResponseMessage() reconnects, sending the request again and leaking that response.
+            val responseMessage = connection.responseMessage
             connection.disconnect()
-            throw IOException("HTTP " + responseCode + ": " + connection.responseMessage)
+            throw IOException("HTTP " + responseCode + ": " + responseMessage)
         }
         return connection
     }


### PR DESCRIPTION
## Problem

`RequestFactory.settings()` handles a non-200 reply as

```kotlin
connection.disconnect()
throw IOException("HTTP " + responseCode + ": " + connection.responseMessage)
```

With the OkHttp-backed `OkHttpURLConnection` (HTTP client v2), `disconnect()` closes the response and sets `connected = false`, and `getResponseMessage()` then calls `connect()` again. So every failed settings fetch sends the request a second time, and that second `Response` is never closed. OkHttp reports it a few minutes later:

```
WARN okhttp3.OkHttpClient : A connection to https://cdn-settings.segment.com/ was leaked. Did you forget to close a response body?
```

Reproduces with any non-200 from the CDN — an invalid write key, or a transient CDN error — once per `Analytics` instance per `checkSettings()`.

## Fix

Read `responseMessage` into a local before `disconnect()`. One request is made and closed; the exception message is unchanged.